### PR TITLE
feat: entity grouping via color association

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the Dataverse ERD Visualizer will be documented in this f
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.9.0] - 2026-02-13
+
+### Added
+
+- **Entity Grouping via Color Association** - Entities sharing the same color automatically form a named group:
+  - **Auto-Derived Groups**: Assigning the same color to multiple entities creates a visual group — no manual group management needed
+  - **Group Names**: Click the pencil icon on any group header to give it a custom name (e.g., "Sales", "Service")
+  - **Collapsible Sections**: Sidebar entity list organizes into collapsible group sections when groups exist, with expand/collapse chevrons
+  - **Group Filter Dropdown**: New "All Groups" filter in sidebar filters — quickly narrow the entity list to a specific group or "Ungrouped"
+  - **Sidebar Legend**: Named groups appear in the legend with their color swatch and entity count
+  - **Snapshot Persistence**: Group names are saved and restored with snapshots (backward compatible — old snapshots load cleanly)
+  - **URL Sharing**: Group names included in shared URLs (only when non-empty, zero overhead otherwise)
+  - **Draw.io Export**: Named groups get color-coded text labels positioned above their entity clusters
+  - **Ungrouped Section**: Entities without color overrides appear in a separate "Ungrouped" section
+
+### Changed
+
+- Sidebar conditionally renders `GroupedEntityList` (with group headers) or flat `VirtualEntityList` based on whether any entities have color overrides
+- "Reset All Colors" now also clears group names and resets the group filter
+
+---
+
 ## [0.1.8.1] - 2026-02-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/version-0.1.8.1_BETA-blue?style=for-the-badge" alt="Version" />
+  <img src="https://img.shields.io/badge/version-0.1.9.0_BETA-blue?style=for-the-badge" alt="Version" />
   <img src="https://img.shields.io/badge/license-MIT-green?style=for-the-badge" alt="License" />
   <a href="https://github.com/allandecastro/dataverse-erd-visualizer/actions/workflows/ci.yml"><img src="https://github.com/allandecastro/dataverse-erd-visualizer/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
   <a href="https://github.com/allandecastro/dataverse-erd-visualizer/actions/workflows/release.yml"><img src="https://github.com/allandecastro/dataverse-erd-visualizer/actions/workflows/release.yml/badge.svg" alt="CD" /></a>
@@ -90,6 +90,7 @@
 | **Draw.io Export**                | Full diagram export compatible with Draw.io and Microsoft Visio                                    |
 | **Dark/Light Mode**               | Professional themes with automatic persistence                                                     |
 | **Custom Colors**                 | Global table colors + per-entity color overrides with palette picker                               |
+| **Entity Grouping**               | Auto-derived groups from shared colors, collapsible sidebar sections, group filter, inline rename  |
 | **Relationship Line Styles**      | Choose between Crow's Foot notation, UML style, or simple arrows                                   |
 | **Line Appearance**               | Solid/dashed/dotted strokes, adjustable thickness (1-5px), color by relationship type (1:N vs N:N) |
 | **Advanced Relationship Visuals** | Professional database notation for technical documentation and presentations                       |
@@ -615,4 +616,3 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 <p align="center">
   Made with ❤️ for the Power Platform Community
 </p>
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataverse-erd-visualizer",
-  "version": "0.1.8.1",
+  "version": "0.1.9.0",
   "description": "Entity Relationship Diagram Visualizer for Microsoft Dataverse",
   "type": "module",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ const FieldDrawer = lazy(() =>
 );
 
 // Types and utilities
-import type { ColorSettings, LayoutMode } from './types/erdTypes';
+import type { ColorSettings, LayoutMode, DerivedGroup } from './types/erdTypes';
 import type { ERDSnapshot } from './types/snapshotTypes';
 import { exportToMermaid } from './utils/exportUtils';
 import { exportToDrawio, downloadDrawio } from './utils/drawioExport';
@@ -120,6 +120,12 @@ export default function ERDVisualizer({
     setEntityColor,
     clearEntityColor,
     clearAllEntityColors,
+    // Entity grouping
+    groupNames,
+    setGroupName,
+    derivedGroups,
+    groupFilter,
+    setGroupFilter,
   } = state;
 
   // Layout algorithms
@@ -408,6 +414,7 @@ export default function ERDVisualizer({
         collapsedEntities,
         colorSettings,
         entityColorOverrides,
+        groupNames,
         onProgress: (progress, message) => {
           setDrawioExportProgress({ progress, message });
         },
@@ -430,6 +437,7 @@ export default function ERDVisualizer({
     collapsedEntities,
     colorSettings,
     entityColorOverrides,
+    groupNames,
     showToast,
     isExportingDrawio,
   ]);
@@ -453,6 +461,7 @@ export default function ERDVisualizer({
         solutionFilter: currentState.solutionFilter,
         isDarkMode: currentState.isDarkMode,
         entityColorOverrides: currentState.entityColorOverrides,
+        groupNames: currentState.groupNames,
       };
 
       // Encode state
@@ -653,6 +662,10 @@ export default function ERDVisualizer({
           onCloseColorPicker={handleCloseColorPicker}
           colorPickerState={colorPickerState}
           onResetAllEntityColors={clearAllEntityColors}
+          derivedGroups={derivedGroups}
+          groupFilter={groupFilter}
+          onGroupFilterChange={setGroupFilter}
+          onSetGroupName={setGroupName}
           onCopyPNG={handleCopyPNG}
           onExportMermaid={handleExportMermaid}
           onExportSVG={handleExportSVG}
@@ -750,6 +763,11 @@ interface ERDVisualizerContentProps {
   onCloseColorPicker: () => void;
   colorPickerState: { entityName: string; anchorPosition: { x: number; y: number } } | null;
   onResetAllEntityColors: () => void;
+  // Entity grouping
+  derivedGroups: DerivedGroup[];
+  groupFilter: string;
+  onGroupFilterChange: (value: string) => void;
+  onSetGroupName: (color: string, name: string) => void;
   onCopyPNG: () => void;
   onExportMermaid: () => void;
   onExportSVG: () => void;
@@ -839,6 +857,10 @@ function ERDVisualizerContent({
   onCloseColorPicker,
   colorPickerState,
   onResetAllEntityColors,
+  derivedGroups,
+  groupFilter,
+  onGroupFilterChange,
+  onSetGroupName,
   onCopyPNG,
   onExportMermaid,
   onExportSVG,
@@ -934,6 +956,11 @@ function ERDVisualizerContent({
         onColorSettingsChange={onColorSettingsChange}
         entityColorOverrideCount={Object.keys(entityColorOverrides).length}
         onResetAllEntityColors={onResetAllEntityColors}
+        entityColorOverrides={entityColorOverrides}
+        derivedGroups={derivedGroups}
+        groupFilter={groupFilter}
+        onGroupFilterChange={onGroupFilterChange}
+        onSetGroupName={onSetGroupName}
       />
 
       {/* Main Canvas Area */}

--- a/src/components/GroupedEntityList.tsx
+++ b/src/components/GroupedEntityList.tsx
@@ -1,0 +1,403 @@
+/**
+ * Grouped entity list with collapsible group sections
+ * Replaces VirtualEntityList when entities have color-based groups
+ */
+
+import { memo, useCallback, useRef, useState, useMemo } from 'react';
+import { ChevronRight, Link2, Pencil } from 'lucide-react';
+import type { Entity } from '@/types';
+import type { ThemeColors, ColorSettings, DerivedGroup } from '@/types/erdTypes';
+import styles from '@/styles/Sidebar.module.css';
+
+const GROUP_HEADER_HEIGHT = 40;
+const ENTITY_ITEM_HEIGHT = 52;
+const OVERSCAN = 5;
+
+/** Flattened list item — either a group header or an entity row */
+type ListItem =
+  | { type: 'group-header'; group: DerivedGroup; entityCount: number; selectedCount: number }
+  | { type: 'entity'; entity: Entity; isSelected: boolean };
+
+export interface GroupedEntityListProps {
+  entities: Entity[];
+  selectedEntities: Set<string>;
+  isDarkMode: boolean;
+  themeColors: ThemeColors;
+  colorSettings: ColorSettings;
+  onToggleEntity: (entityName: string) => void;
+  containerHeight: number;
+  derivedGroups: DerivedGroup[];
+  onSetGroupName: (color: string, name: string) => void;
+}
+
+export const GroupedEntityList = memo(function GroupedEntityList({
+  entities,
+  selectedEntities,
+  isDarkMode,
+  themeColors,
+  colorSettings,
+  onToggleEntity,
+  containerHeight,
+  derivedGroups,
+  onSetGroupName,
+}: GroupedEntityListProps) {
+  const { borderColor, textSecondary } = themeColors;
+  const { customTableColor, standardTableColor, lookupColor } = colorSettings;
+
+  // Local collapse state (not persisted)
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+  // Inline rename state
+  const [renamingGroup, setRenamingGroup] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const renameInputRef = useRef<HTMLInputElement>(null);
+
+  // Build entity lookup by logical name for O(1) access
+  const entityMap = useMemo(() => {
+    const map = new Map<string, Entity>();
+    for (const entity of entities) {
+      map.set(entity.logicalName, entity);
+    }
+    return map;
+  }, [entities]);
+
+  // Set of entity names that appear in the current `entities` list (post-filter)
+  const visibleEntityNames = useMemo(() => {
+    return new Set(entities.map((e) => e.logicalName));
+  }, [entities]);
+
+  // Build the flattened list of items
+  const flatItems = useMemo(() => {
+    const items: ListItem[] = [];
+    const groupedEntityNames = new Set<string>();
+
+    for (const group of derivedGroups) {
+      // Only include entities that are in the visible (filtered) list
+      const groupEntities = group.entityNames.filter((name) => visibleEntityNames.has(name));
+      if (groupEntities.length === 0) continue;
+
+      const selectedCount = groupEntities.filter((name) => selectedEntities.has(name)).length;
+      items.push({
+        type: 'group-header',
+        group,
+        entityCount: groupEntities.length,
+        selectedCount,
+      });
+
+      if (!collapsedGroups.has(group.color)) {
+        for (const name of groupEntities) {
+          const entity = entityMap.get(name);
+          if (entity) {
+            items.push({
+              type: 'entity',
+              entity,
+              isSelected: selectedEntities.has(name),
+            });
+          }
+        }
+      }
+
+      for (const name of groupEntities) {
+        groupedEntityNames.add(name);
+      }
+    }
+
+    // Ungrouped entities (no color override)
+    const ungroupedEntities = entities.filter((e) => !groupedEntityNames.has(e.logicalName));
+    if (ungroupedEntities.length > 0) {
+      const ungroupedSelectedCount = ungroupedEntities.filter((e) =>
+        selectedEntities.has(e.logicalName)
+      ).length;
+
+      items.push({
+        type: 'group-header',
+        group: {
+          color: '__ungrouped__',
+          name: 'Ungrouped',
+          entityNames: ungroupedEntities.map((e) => e.logicalName),
+        },
+        entityCount: ungroupedEntities.length,
+        selectedCount: ungroupedSelectedCount,
+      });
+
+      if (!collapsedGroups.has('__ungrouped__')) {
+        for (const entity of ungroupedEntities) {
+          items.push({
+            type: 'entity',
+            entity,
+            isSelected: selectedEntities.has(entity.logicalName),
+          });
+        }
+      }
+    }
+
+    return items;
+  }, [derivedGroups, entities, selectedEntities, collapsedGroups, entityMap, visibleEntityNames]);
+
+  // Cumulative offset array for variable-height virtual scrolling
+  const { offsets, totalHeight } = useMemo(() => {
+    const offs = new Array<number>(flatItems.length + 1);
+    offs[0] = 0;
+    for (let i = 0; i < flatItems.length; i++) {
+      offs[i + 1] =
+        offs[i] + (flatItems[i].type === 'group-header' ? GROUP_HEADER_HEIGHT : ENTITY_ITEM_HEIGHT);
+    }
+    return { offsets: offs, totalHeight: offs[flatItems.length] };
+  }, [flatItems]);
+
+  // Use the fixed-height virtual scroll hook with an average item height
+  // We'll compute our own visible range using binary search instead
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+
+  const onScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    setScrollTop((e.target as HTMLDivElement).scrollTop);
+  }, []);
+
+  // Binary search for first visible item
+  const visibleRange = useMemo(() => {
+    const viewStart = scrollTop;
+    const viewEnd = scrollTop + containerHeight;
+
+    // Binary search for start index
+    let lo = 0;
+    let hi = flatItems.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1;
+      if (offsets[mid + 1] <= viewStart) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+    const startIdx = Math.max(0, lo - OVERSCAN);
+
+    // Find end index
+    let endIdx = lo;
+    while (endIdx < flatItems.length && offsets[endIdx] < viewEnd) {
+      endIdx++;
+    }
+    endIdx = Math.min(flatItems.length - 1, endIdx + OVERSCAN);
+
+    return { startIdx, endIdx };
+  }, [scrollTop, containerHeight, flatItems.length, offsets]);
+
+  const toggleGroup = useCallback((color: string) => {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(color)) {
+        next.delete(color);
+      } else {
+        next.add(color);
+      }
+      return next;
+    });
+  }, []);
+
+  const startRename = useCallback((color: string, currentName: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setRenamingGroup(color);
+    setRenameValue(currentName);
+    // Focus input after render
+    setTimeout(() => renameInputRef.current?.focus(), 0);
+  }, []);
+
+  const confirmRename = useCallback(() => {
+    if (renamingGroup && renameValue.trim()) {
+      onSetGroupName(renamingGroup, renameValue.trim());
+    }
+    setRenamingGroup(null);
+    setRenameValue('');
+  }, [renamingGroup, renameValue, onSetGroupName]);
+
+  const cancelRename = useCallback(() => {
+    setRenamingGroup(null);
+    setRenameValue('');
+  }, []);
+
+  const handleRenameKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        confirmRename();
+      } else if (e.key === 'Escape') {
+        cancelRename();
+      }
+    },
+    [confirmRename, cancelRename]
+  );
+
+  return (
+    <div
+      ref={containerRef}
+      onScroll={onScroll}
+      role="tree"
+      aria-label="Grouped entity list"
+      style={{
+        height: containerHeight,
+        overflow: 'auto',
+        position: 'relative',
+      }}
+    >
+      <div style={{ height: totalHeight, position: 'relative' }}>
+        {flatItems.map((item, idx) => {
+          if (idx < visibleRange.startIdx || idx > visibleRange.endIdx) return null;
+
+          if (item.type === 'group-header') {
+            const isCollapsed = collapsedGroups.has(item.group.color);
+            const isUngrouped = item.group.color === '__ungrouped__';
+            const isRenaming = renamingGroup === item.group.color;
+
+            return (
+              <div
+                key={`group-${item.group.color}`}
+                className={styles.groupHeader}
+                onClick={() => toggleGroup(item.group.color)}
+                style={{
+                  position: 'absolute',
+                  top: offsets[idx],
+                  left: 0,
+                  right: 0,
+                  height: GROUP_HEADER_HEIGHT,
+                  borderBottom: `1px solid ${borderColor}`,
+                  background: isDarkMode ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.02)',
+                }}
+                role="treeitem"
+                aria-expanded={!isCollapsed}
+              >
+                <ChevronRight
+                  size={14}
+                  className={`${styles.groupChevron} ${isCollapsed ? '' : styles.groupChevronExpanded}`}
+                  style={{ color: textSecondary }}
+                />
+                {!isUngrouped && (
+                  <div
+                    className={styles.groupColorSwatch}
+                    style={{ background: item.group.color }}
+                  />
+                )}
+                {isRenaming ? (
+                  <input
+                    ref={renameInputRef}
+                    type="text"
+                    value={renameValue}
+                    onChange={(e) => setRenameValue(e.target.value)}
+                    onBlur={confirmRename}
+                    onKeyDown={handleRenameKeyDown}
+                    onClick={(e) => e.stopPropagation()}
+                    className={styles.groupRenameInput}
+                    style={{
+                      color: isDarkMode ? '#e2e8f0' : '#1e293b',
+                      background: isDarkMode ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.05)',
+                      borderColor: borderColor,
+                    }}
+                  />
+                ) : (
+                  <span className={styles.groupName}>{item.group.name}</span>
+                )}
+                <span className={styles.groupCount} style={{ color: textSecondary }}>
+                  {item.selectedCount}/{item.entityCount}
+                </span>
+                {!isUngrouped && !isRenaming && (
+                  <button
+                    className={styles.groupRenameBtn}
+                    onClick={(e) => startRename(item.group.color, item.group.name, e)}
+                    title="Rename group"
+                    style={{ color: textSecondary }}
+                  >
+                    <Pencil size={12} />
+                  </button>
+                )}
+              </div>
+            );
+          }
+
+          // Entity item
+          const { entity, isSelected } = item;
+          const hasLookups = entity.attributes.some(
+            (a) => a.type === 'Lookup' || a.type === 'Owner'
+          );
+
+          return (
+            <div
+              key={entity.logicalName}
+              role="treeitem"
+              aria-selected={isSelected}
+              onClick={() => onToggleEntity(entity.logicalName)}
+              style={{
+                position: 'absolute',
+                top: offsets[idx],
+                left: 0,
+                right: 0,
+                height: ENTITY_ITEM_HEIGHT,
+                display: 'flex',
+                alignItems: 'center',
+                gap: '10px',
+                padding: '8px 12px 8px 28px',
+                boxSizing: 'border-box',
+                borderRadius: '4px',
+                cursor: 'pointer',
+                background: isSelected
+                  ? isDarkMode
+                    ? 'rgba(255,255,255,0.08)'
+                    : 'rgba(0,0,0,0.04)'
+                  : 'transparent',
+                border: `1px solid ${isSelected ? borderColor : 'transparent'}`,
+                transition: 'all 0.15s',
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={isSelected}
+                onChange={() => {}}
+                tabIndex={-1}
+                aria-hidden="true"
+                style={{ cursor: 'pointer', accentColor: customTableColor }}
+              />
+              <div
+                style={{
+                  width: '8px',
+                  height: '8px',
+                  borderRadius: '2px',
+                  background: entity.isCustomEntity ? customTableColor : standardTableColor,
+                  flexShrink: 0,
+                }}
+                aria-hidden="true"
+              />
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div
+                  style={{
+                    fontSize: '13px',
+                    fontWeight: '500',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {entity.displayName}
+                </div>
+                <div
+                  style={{
+                    fontSize: '11px',
+                    color: textSecondary,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {entity.logicalName}
+                </div>
+              </div>
+              {hasLookups && (
+                <Link2
+                  size={14}
+                  color={lookupColor}
+                  style={{ flexShrink: 0 }}
+                  aria-label="Has lookup relationships"
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+});

--- a/src/components/SidebarFilters.tsx
+++ b/src/components/SidebarFilters.tsx
@@ -4,7 +4,7 @@
 
 import { memo } from 'react';
 import { Search, Eye, EyeOff } from 'lucide-react';
-import type { LayoutMode } from '@/types/erdTypes';
+import type { LayoutMode, DerivedGroup } from '@/types/erdTypes';
 import styles from '@/styles/Sidebar.module.css';
 
 export interface SidebarFiltersProps {
@@ -24,6 +24,9 @@ export interface SidebarFiltersProps {
   onLayoutModeChange: (mode: LayoutMode) => void;
   onExpandAll: () => void;
   onCollapseAll: () => void;
+  groupFilter: string;
+  groups: DerivedGroup[];
+  onGroupFilterChange: (value: string) => void;
 }
 
 export const SidebarFilters = memo(function SidebarFilters({
@@ -43,6 +46,9 @@ export const SidebarFilters = memo(function SidebarFilters({
   onLayoutModeChange,
   onExpandAll,
   onCollapseAll,
+  groupFilter,
+  groups,
+  onGroupFilterChange,
 }: SidebarFiltersProps) {
   const smallButtonBg = isDarkMode ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.02)';
   const inputBg = isDarkMode ? '#1a1a1a' : '#ffffff';
@@ -111,7 +117,7 @@ export const SidebarFilters = memo(function SidebarFilters({
           backgroundRepeat: 'no-repeat',
           backgroundPosition: 'calc(100% - 12px) center',
           backgroundSize: '12px 12px',
-          marginBottom: '12px',
+          marginBottom: groups.length > 0 ? '8px' : '12px',
         }}
       >
         <option value="all">All Solutions</option>
@@ -123,6 +129,33 @@ export const SidebarFilters = memo(function SidebarFilters({
             </option>
           ))}
       </select>
+
+      {groups.length > 0 && (
+        <select
+          key={`group-${isDarkMode}`}
+          value={groupFilter}
+          onChange={(e) => onGroupFilterChange(e.target.value)}
+          className={styles.select}
+          style={{
+            backgroundColor: inputBg,
+            border: `1px solid ${borderColor}`,
+            color: textColor,
+            backgroundImage: selectArrowBg,
+            backgroundRepeat: 'no-repeat',
+            backgroundPosition: 'calc(100% - 12px) center',
+            backgroundSize: '12px 12px',
+            marginBottom: '12px',
+          }}
+        >
+          <option value="all">All Groups</option>
+          {groups.map((group) => (
+            <option key={group.color} value={group.color}>
+              {group.name} ({group.entityNames.length})
+            </option>
+          ))}
+          <option value="__ungrouped__">Ungrouped</option>
+        </select>
+      )}
 
       {/* Layout Mode */}
       <select

--- a/src/components/SidebarLegend.tsx
+++ b/src/components/SidebarLegend.tsx
@@ -4,17 +4,19 @@
 
 import { memo } from 'react';
 import { Link2 } from 'lucide-react';
-import type { ColorSettings } from '@/types/erdTypes';
+import type { ColorSettings, DerivedGroup } from '@/types/erdTypes';
 import styles from '@/styles/Sidebar.module.css';
 
 export interface SidebarLegendProps {
   colorSettings: ColorSettings;
   borderColor: string;
+  derivedGroups: DerivedGroup[];
 }
 
 export const SidebarLegend = memo(function SidebarLegend({
   colorSettings,
   borderColor,
+  derivedGroups,
 }: SidebarLegendProps) {
   const { customTableColor, standardTableColor, lookupColor } = colorSettings;
 
@@ -34,6 +36,14 @@ export const SidebarLegend = memo(function SidebarLegend({
           <Link2 size={14} color={lookupColor} />
           <span>Has Lookup Fields</span>
         </div>
+        {derivedGroups.map((group) => (
+          <div key={group.color} className={styles.legendItem}>
+            <div className={styles.legendColor} style={{ background: group.color }} />
+            <span>
+              {group.name} ({group.entityNames.length})
+            </span>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/styles/Sidebar.module.css
+++ b/src/styles/Sidebar.module.css
@@ -304,6 +304,83 @@
   color: inherit;
 }
 
+/* Grouped Entity List */
+.groupHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.groupHeader:hover {
+  background: rgba(128, 128, 128, 0.08) !important;
+}
+
+.groupChevron {
+  flex-shrink: 0;
+  transition: transform 0.15s;
+}
+
+.groupChevronExpanded {
+  transform: rotate(90deg);
+}
+
+.groupColorSwatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.groupName {
+  font-size: 13px;
+  font-weight: 600;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.groupCount {
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.groupRenameInput {
+  flex: 1;
+  min-width: 0;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border: 1px solid;
+  border-radius: 3px;
+  outline: none;
+}
+
+.groupRenameBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 3px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.groupHeader:hover .groupRenameBtn {
+  opacity: 1;
+}
+
+.groupRenameBtn:hover {
+  background: rgba(128, 128, 128, 0.15);
+}
+
 /* Legend Component */
 .legend {
   padding: 16px;

--- a/src/types/erdTypes.ts
+++ b/src/types/erdTypes.ts
@@ -53,6 +53,13 @@ export interface ColorSettings {
   manyToManyColor?: string;
 }
 
+// Derived group — computed at runtime from entityColorOverrides + groupNames
+export interface DerivedGroup {
+  color: string; // hex color key (lowercase)
+  name: string; // user-assigned name or auto-label ("Red", "Blue", etc.)
+  entityNames: string[]; // sorted logical names of entities in this group
+}
+
 // ERD State shared across components
 export interface ERDState {
   // Theme
@@ -116,6 +123,14 @@ export interface ERDState {
   setEntityColor: (entityName: string, color: string) => void;
   clearEntityColor: (entityName: string) => void;
   clearAllEntityColors: () => void;
+
+  // Entity grouping (derived from color overrides)
+  groupNames: Record<string, string>;
+  setGroupName: (color: string, name: string) => void;
+  clearGroupName: (color: string) => void;
+  derivedGroups: DerivedGroup[];
+  groupFilter: string;
+  setGroupFilter: (value: string) => void;
 
   // Features
   showMinimap: boolean;

--- a/src/types/snapshotTypes.ts
+++ b/src/types/snapshotTypes.ts
@@ -42,6 +42,9 @@ export interface SerializableState {
 
   // Per-entity color overrides (entity logicalName → hex color)
   entityColorOverrides?: Record<string, string>;
+
+  // Group names (hex color → user-assigned group name)
+  groupNames?: Record<string, string>;
 }
 
 /**

--- a/src/utils/__tests__/drawioExport.test.ts
+++ b/src/utils/__tests__/drawioExport.test.ts
@@ -561,4 +561,60 @@ describe('drawioExport', () => {
       expect(endTime - startTime).toBeLessThan(2000); // Should complete in under 2 seconds
     });
   });
+
+  describe('group labels in draw.io export', () => {
+    it('should add group label cells for named groups', async () => {
+      const blob = await exportToDrawio({
+        ...baseOptions,
+        entityColorOverrides: {
+          account: '#ef4444',
+          contact: '#ef4444',
+        },
+        groupNames: { '#ef4444': 'Sales Entities' },
+      });
+
+      const text = await blobToText(blob);
+      expect(text).toContain('Sales Entities');
+      expect(text).toContain('fontColor=#ef4444');
+    });
+
+    it('should not add group labels when groupNames is empty', async () => {
+      const blob = await exportToDrawio({
+        ...baseOptions,
+        entityColorOverrides: { account: '#ef4444' },
+        groupNames: {},
+      });
+
+      const text = await blobToText(blob);
+      // Should not contain group-label IDs
+      expect(text).not.toContain('group-label');
+    });
+
+    it('should not add group labels when groupNames is undefined', async () => {
+      const blob = await exportToDrawio({
+        ...baseOptions,
+        entityColorOverrides: { account: '#ef4444' },
+      });
+
+      const text = await blobToText(blob);
+      expect(text).not.toContain('group-label');
+    });
+
+    it('should only label groups that have user-assigned names', async () => {
+      const blob = await exportToDrawio({
+        ...baseOptions,
+        entityColorOverrides: {
+          account: '#ef4444',
+          contact: '#3b82f6',
+        },
+        groupNames: { '#ef4444': 'Named Group' },
+        // #3b82f6 has no name — should NOT get a label
+      });
+
+      const text = await blobToText(blob);
+      expect(text).toContain('Named Group');
+      // Should not have a label for the unnamed blue group
+      expect(text).not.toContain('fontColor=#3b82f6');
+    });
+  });
 });

--- a/src/utils/__tests__/groupUtils.test.ts
+++ b/src/utils/__tests__/groupUtils.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for groupUtils — entity grouping via color association
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateColorLabel, deriveGroups, PRESET_COLOR_LABELS } from '../groupUtils';
+
+describe('groupUtils', () => {
+  describe('PRESET_COLOR_LABELS', () => {
+    it('should have 10 preset colors', () => {
+      expect(Object.keys(PRESET_COLOR_LABELS)).toHaveLength(10);
+    });
+
+    it('should map lowercase hex to readable color names', () => {
+      expect(PRESET_COLOR_LABELS['#ef4444']).toBe('Red');
+      expect(PRESET_COLOR_LABELS['#3b82f6']).toBe('Blue');
+      expect(PRESET_COLOR_LABELS['#22c55e']).toBe('Green');
+      expect(PRESET_COLOR_LABELS['#64748b']).toBe('Slate');
+    });
+  });
+
+  describe('generateColorLabel', () => {
+    it('should return preset name for known colors', () => {
+      expect(generateColorLabel('#ef4444')).toBe('Red');
+      expect(generateColorLabel('#f97316')).toBe('Orange');
+      expect(generateColorLabel('#eab308')).toBe('Yellow');
+      expect(generateColorLabel('#22c55e')).toBe('Green');
+      expect(generateColorLabel('#14b8a6')).toBe('Teal');
+      expect(generateColorLabel('#0ea5e9')).toBe('Sky');
+      expect(generateColorLabel('#3b82f6')).toBe('Blue');
+      expect(generateColorLabel('#8b5cf6')).toBe('Violet');
+      expect(generateColorLabel('#ec4899')).toBe('Pink');
+      expect(generateColorLabel('#64748b')).toBe('Slate');
+    });
+
+    it('should be case-insensitive for preset colors', () => {
+      expect(generateColorLabel('#EF4444')).toBe('Red');
+      expect(generateColorLabel('#3B82F6')).toBe('Blue');
+    });
+
+    it('should return uppercase hex for custom colors', () => {
+      expect(generateColorLabel('#ff00ff')).toBe('#FF00FF');
+      expect(generateColorLabel('#123abc')).toBe('#123ABC');
+    });
+  });
+
+  describe('deriveGroups', () => {
+    it('should return empty array when no color overrides exist', () => {
+      const groups = deriveGroups({}, {});
+      expect(groups).toEqual([]);
+    });
+
+    it('should group entities by shared color', () => {
+      const colorOverrides = {
+        account: '#ef4444',
+        contact: '#ef4444',
+        opportunity: '#3b82f6',
+      };
+      const groups = deriveGroups(colorOverrides, {});
+
+      expect(groups).toHaveLength(2);
+      // Sorted by name: Blue < Red
+      expect(groups[0].name).toBe('Blue');
+      expect(groups[0].entityNames).toEqual(['opportunity']);
+      expect(groups[1].name).toBe('Red');
+      expect(groups[1].entityNames).toEqual(['account', 'contact']);
+    });
+
+    it('should use user-assigned group names when available', () => {
+      const colorOverrides = {
+        account: '#ef4444',
+        contact: '#ef4444',
+      };
+      const groupNames = { '#ef4444': 'Sales' };
+      const groups = deriveGroups(colorOverrides, groupNames);
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].name).toBe('Sales');
+      expect(groups[0].entityNames).toEqual(['account', 'contact']);
+    });
+
+    it('should normalize colors to lowercase', () => {
+      const colorOverrides = {
+        account: '#EF4444',
+        contact: '#ef4444',
+      };
+      const groups = deriveGroups(colorOverrides, {});
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].color).toBe('#ef4444');
+      expect(groups[0].entityNames).toEqual(['account', 'contact']);
+    });
+
+    it('should sort entity names within each group', () => {
+      const colorOverrides = {
+        zebra_entity: '#ef4444',
+        alpha_entity: '#ef4444',
+        middle_entity: '#ef4444',
+      };
+      const groups = deriveGroups(colorOverrides, {});
+
+      expect(groups[0].entityNames).toEqual(['alpha_entity', 'middle_entity', 'zebra_entity']);
+    });
+
+    it('should sort groups alphabetically by name', () => {
+      const colorOverrides = {
+        entity_a: '#ec4899', // Pink
+        entity_b: '#22c55e', // Green
+        entity_c: '#ef4444', // Red
+      };
+      const groups = deriveGroups(colorOverrides, {});
+
+      expect(groups.map((g) => g.name)).toEqual(['Green', 'Pink', 'Red']);
+    });
+
+    it('should handle custom colors with hex label', () => {
+      const colorOverrides = {
+        entity_a: '#ff00ff',
+      };
+      const groups = deriveGroups(colorOverrides, {});
+
+      expect(groups[0].name).toBe('#FF00FF');
+      expect(groups[0].color).toBe('#ff00ff');
+    });
+
+    it('should handle single entity per group', () => {
+      const colorOverrides = {
+        entity_a: '#ef4444',
+      };
+      const groups = deriveGroups(colorOverrides, {});
+
+      expect(groups).toHaveLength(1);
+      expect(groups[0].entityNames).toEqual(['entity_a']);
+    });
+
+    it('should use user name over auto-label', () => {
+      const colorOverrides = {
+        entity_a: '#ef4444',
+      };
+      const groupNames = { '#ef4444': 'My Custom Group' };
+      const groups = deriveGroups(colorOverrides, groupNames);
+
+      expect(groups[0].name).toBe('My Custom Group');
+    });
+
+    it('should handle multiple groups with mixed named/unnamed', () => {
+      const colorOverrides = {
+        entity_a: '#ef4444',
+        entity_b: '#3b82f6',
+        entity_c: '#22c55e',
+      };
+      const groupNames = { '#ef4444': 'CRM Entities' };
+      const groups = deriveGroups(colorOverrides, groupNames);
+
+      expect(groups).toHaveLength(3);
+      // Sorted: Blue < CRM Entities < Green
+      expect(groups[0].name).toBe('Blue');
+      expect(groups[1].name).toBe('CRM Entities');
+      expect(groups[2].name).toBe('Green');
+    });
+
+    it('should handle orphaned group names gracefully', () => {
+      // groupNames has entries for colors not in entityColorOverrides
+      const colorOverrides = {
+        entity_a: '#ef4444',
+      };
+      const groupNames = {
+        '#ef4444': 'Active',
+        '#3b82f6': 'Orphaned Name', // No entities have this color
+      };
+      const groups = deriveGroups(colorOverrides, groupNames);
+
+      // Should only have 1 group (the one with entities)
+      expect(groups).toHaveLength(1);
+      expect(groups[0].name).toBe('Active');
+    });
+  });
+});

--- a/src/utils/groupUtils.ts
+++ b/src/utils/groupUtils.ts
@@ -1,0 +1,62 @@
+/**
+ * Utility functions for entity grouping via color association.
+ *
+ * Groups are derived from entityColorOverrides — entities sharing the same
+ * color override belong to the same group. Group names map hex colors to
+ * user-defined labels.
+ */
+
+import type { DerivedGroup } from '@/types/erdTypes';
+
+/** Maps the 10 preset colors (from ColorPickerPopover) to readable names */
+export const PRESET_COLOR_LABELS: Record<string, string> = {
+  '#ef4444': 'Red',
+  '#f97316': 'Orange',
+  '#eab308': 'Yellow',
+  '#22c55e': 'Green',
+  '#14b8a6': 'Teal',
+  '#0ea5e9': 'Sky',
+  '#3b82f6': 'Blue',
+  '#8b5cf6': 'Violet',
+  '#ec4899': 'Pink',
+  '#64748b': 'Slate',
+};
+
+/**
+ * Generate a human-readable label for a hex color.
+ * Returns the preset name for known colors, or the uppercase hex code for custom colors.
+ */
+export function generateColorLabel(hexColor: string): string {
+  return PRESET_COLOR_LABELS[hexColor.toLowerCase()] || hexColor.toUpperCase();
+}
+
+/**
+ * Derive groups from entity color overrides and group names.
+ * Pure function — can be used directly or inside useMemo.
+ *
+ * @returns Sorted array of derived groups (by name, alphabetically)
+ */
+export function deriveGroups(
+  entityColorOverrides: Record<string, string>,
+  groupNames: Record<string, string>
+): DerivedGroup[] {
+  const colorToEntities = new Map<string, string[]>();
+
+  for (const [entityName, color] of Object.entries(entityColorOverrides)) {
+    const normalized = color.toLowerCase();
+    const existing = colorToEntities.get(normalized);
+    if (existing) {
+      existing.push(entityName);
+    } else {
+      colorToEntities.set(normalized, [entityName]);
+    }
+  }
+
+  return Array.from(colorToEntities.entries())
+    .map(([color, entityNames]) => ({
+      color,
+      name: groupNames[color] || generateColorLabel(color),
+      entityNames: entityNames.sort(),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/src/utils/urlStateCodec.ts
+++ b/src/utils/urlStateCodec.ts
@@ -30,6 +30,7 @@ export interface CompactState {
   d: boolean; // isDarkMode
   v: string; // version
   co?: Record<string, string>; // entityColorOverrides (optional, only present when non-empty)
+  gn?: Record<string, string>; // groupNames (optional, only present when non-empty)
 }
 
 /**
@@ -83,6 +84,7 @@ export function encodeStateToURL(state: {
   solutionFilter: string;
   isDarkMode: boolean;
   entityColorOverrides?: Record<string, string>;
+  groupNames?: Record<string, string>;
 }): string {
   try {
     // Build compact state object
@@ -107,6 +109,11 @@ export function encodeStateToURL(state: {
     // Only include color overrides if non-empty (saves URL space)
     if (state.entityColorOverrides && Object.keys(state.entityColorOverrides).length > 0) {
       compactState.co = state.entityColorOverrides;
+    }
+
+    // Only include group names if non-empty
+    if (state.groupNames && Object.keys(state.groupNames).length > 0) {
+      compactState.gn = state.groupNames;
     }
 
     // Serialize to JSON
@@ -190,6 +197,8 @@ export function expandCompactState(compact: CompactState): Partial<SerializableS
     isDarkMode: compact.d,
     // Restore per-entity color overrides if present
     ...(compact.co ? { entityColorOverrides: compact.co } : {}),
+    // Restore group names if present
+    ...(compact.gn ? { groupNames: compact.gn } : {}),
     // Fields NOT restored from URL (use existing state or defaults):
     // - collapsedEntities
     // - selectedFields


### PR DESCRIPTION
Auto-derive groups from shared entity colors with collapsible sidebar sections, group filter dropdown, inline rename, and persistence via snapshots and shared URLs. Groups appear in the legend and as labeled clusters in Draw.io exports.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Enhancement (improvement to existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

<!-- Link any related issues here using #issue_number -->

Fixes #

## Changes Made

<!-- List the main changes made in this PR -->

-
-
-

## Screenshots

<!-- If applicable, add screenshots to demonstrate the changes -->

## Testing

<!-- Describe how you tested your changes -->

- [ ] Tested in development mode (`npm run dev`)
- [ ] Tested build (`npm run build`)
- [ ] Tested web resource build (`npm run build:webresource`)
- [ ] Tested in Dataverse environment

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation if needed
- [ ] My changes generate no new warnings
- [ ] The build passes locally

## Additional Notes

<!-- Any additional information that reviewers should know -->
