### PR TITLE
feat: auto-update banner with in-place Dataverse solution import

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,53 @@ jobs:
         run: |
           Compress-Archive -Path "dist/webresource/*" -DestinationPath "webresources_${{ steps.version.outputs.VERSION }}.zip"
 
+      - name: Generate GitHub Pages update payload
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.VERSION }}"
+          $zipPath = "DataverseERDVisualizer_${version}_managed.zip"
+
+          # Base64-encode the managed solution so it can be delivered as an
+          # executable JS payload (a <script> include bypasses CORS in the
+          # Dataverse iframe, unlike a direct binary download).
+          $bytes = [System.IO.File]::ReadAllBytes((Resolve-Path $zipPath))
+          $b64 = [System.Convert]::ToBase64String($bytes)
+
+          $outDir = "pages-out/update"
+          New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+
+          $payload = @{ version = $version; data = $b64 } | ConvertTo-Json -Compress
+
+          # JSON payload — preferred, fetched cross-origin as data (Pages sends ACAO).
+          Set-Content -Path "$outDir/v$version.json" -Value $payload -Encoding utf8NoBOM -NoNewline
+
+          # JS payload — <script>-include fallback (CORS-exempt) for restrictive CSPs.
+          $js = "window.__ERD_SOLUTION_UPDATE__ = $payload;"
+          Set-Content -Path "$outDir/v$version.js" -Value $js -Encoding utf8NoBOM -NoNewline
+
+          # Publish a manifest with the SRI hash for optional integrity checks.
+          $sha = [System.Security.Cryptography.SHA384]::Create().ComputeHash(
+            [System.Text.Encoding]::UTF8.GetBytes($js)
+          )
+          $integrity = "sha384-" + [System.Convert]::ToBase64String($sha)
+          @{ version = $version; js = "update/v$version.js"; integrity = $integrity } |
+            ConvertTo-Json -Compress |
+            Set-Content -Path "pages-out/update/latest.json" -Encoding utf8NoBOM -NoNewline
+
+          Write-Host "Update payload generated for v$version ($integrity)"
+
+      - name: Publish update payload to GitHub Pages
+        if: steps.version.outputs.IS_TAG == 'true'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./pages-out
+          publish_branch: gh-pages
+          keep_files: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'chore(pages): publish update payload v${{ steps.version.outputs.VERSION }}'
+
       - name: Upload managed solution artifact
         uses: actions/upload-artifact@v7
         with:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import {
 import { ReactFlowERD, type ReactFlowERDRef } from './components/ReactFlowERD';
 import { AddRelatedTableDialog } from './components/AddRelatedTableDialog';
 import { ColorPickerPopover } from './components/ColorPickerPopover';
+import { UpdateBanner } from './components/UpdateBanner';
 
 // Components - lazy loaded (not immediately needed)
 const FeatureGuide = lazy(() =>
@@ -1091,6 +1092,9 @@ function ERDVisualizerContent({
           />
         </main>
       </div>
+
+      {/* Auto-update banner (checks GitHub releases on load) */}
+      <UpdateBanner />
 
       {/* Toast Notification */}
       {toast && <Toast message={toast.message} type={toast.type} />}

--- a/src/components/SidebarSettings.tsx
+++ b/src/components/SidebarSettings.tsx
@@ -2,8 +2,9 @@
  * Sidebar color settings panel
  */
 
-import { memo } from 'react';
+import { memo, useState } from 'react';
 import type { ColorSettings } from '@/types/erdTypes';
+import { getUpdateCheckEnabled, setUpdateCheckEnabled } from '@/services/updatePreferences';
 import styles from '@/styles/Sidebar.module.css';
 
 export interface SidebarSettingsProps {
@@ -41,6 +42,13 @@ export const SidebarSettings = memo(function SidebarSettings({
   } = colorSettings;
   const panelBg = isDarkMode ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.02)';
   const inputBg = isDarkMode ? '#1a1a1a' : '#ffffff';
+
+  // Auto-update preference (persisted to localStorage; applied on next load)
+  const [updateCheckEnabled, setUpdateCheckEnabledState] = useState(getUpdateCheckEnabled);
+  const handleUpdateCheckToggle = (checked: boolean) => {
+    setUpdateCheckEnabledState(checked);
+    setUpdateCheckEnabled(checked);
+  };
 
   // SVG chevron arrow for select dropdown
   const arrowColor = isDarkMode ? '%23e2e8f0' : '%231e293b';
@@ -260,6 +268,27 @@ export const SidebarSettings = memo(function SidebarSettings({
               style={{ marginRight: '8px', cursor: 'pointer' }}
             />
             Show Lookup IDs on Relationship Lines
+          </label>
+        </div>
+
+        {/* Check for Updates Checkbox */}
+        <div style={{ gridColumn: '1 / -1' }}>
+          <label
+            className={styles.settingsLabel}
+            style={{
+              color: textSecondary,
+              display: 'flex',
+              alignItems: 'center',
+              cursor: 'pointer',
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={updateCheckEnabled}
+              onChange={(e) => handleUpdateCheckToggle(e.target.checked)}
+              style={{ marginRight: '8px', cursor: 'pointer' }}
+            />
+            Check for updates on load
           </label>
         </div>
 

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,0 +1,142 @@
+/**
+ * UpdateBanner
+ * Persistent, dismissible banner shown at the top of the app when a newer
+ * release is available on GitHub. Lets an admin download and import the managed
+ * solution into the current Dataverse environment in place.
+ */
+
+import { AlertTriangle, CheckCircle2, Download, RefreshCw, X } from 'lucide-react';
+import { useUpdateCheck } from '@/hooks/useUpdateCheck';
+import styles from '@/styles/UpdateBanner.module.css';
+
+export function UpdateBanner() {
+  const { status, startUpdate, dismiss } = useUpdateCheck();
+
+  // Nothing to show while idle / checking / already up to date.
+  if (status.phase === 'idle' || status.phase === 'checking' || status.phase === 'upToDate') {
+    return null;
+  }
+
+  const variantClass =
+    status.phase === 'error'
+      ? styles.error
+      : status.phase === 'done'
+        ? styles.success
+        : styles.info;
+
+  return (
+    <div className={`${styles.banner} ${variantClass}`} role="status" aria-live="polite">
+      <span className={styles.icon}>
+        {status.phase === 'error' ? (
+          <AlertTriangle size={18} />
+        ) : status.phase === 'done' ? (
+          <CheckCircle2 size={18} />
+        ) : status.phase === 'downloading' || status.phase === 'importing' ? (
+          <RefreshCw size={18} className={styles.spinner} />
+        ) : (
+          <Download size={18} />
+        )}
+      </span>
+
+      <div className={styles.content}>
+        {status.phase === 'available' && (
+          <>
+            <span className={styles.message}>
+              A new version is available: v{status.current} → v{status.latest.version}
+            </span>
+            <a
+              className={styles.releaseLink}
+              href={status.latest.htmlUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View release notes
+            </a>
+          </>
+        )}
+
+        {status.phase === 'downloading' && (
+          <>
+            <span className={styles.message}>Downloading update v{status.latest.version}…</span>
+            <div className={styles.progressTrack}>
+              <div className={`${styles.progressBar} ${styles.progressIndeterminate}`} />
+            </div>
+          </>
+        )}
+
+        {status.phase === 'importing' && (
+          <>
+            <span className={styles.message}>
+              Importing solution into Dataverse
+              {typeof status.progress === 'number' ? ` — ${Math.round(status.progress)}%` : '…'}
+            </span>
+            <div className={styles.progressTrack}>
+              <div
+                className={
+                  typeof status.progress === 'number'
+                    ? styles.progressBar
+                    : `${styles.progressBar} ${styles.progressIndeterminate}`
+                }
+                style={
+                  typeof status.progress === 'number'
+                    ? { width: `${Math.max(0, Math.min(100, status.progress))}%` }
+                    : undefined
+                }
+              />
+            </div>
+          </>
+        )}
+
+        {status.phase === 'done' && (
+          <span className={styles.message}>
+            Version {status.latest.version} installed. Reload to use the updated app.
+          </span>
+        )}
+
+        {status.phase === 'error' && (
+          <>
+            <span className={styles.message}>{status.message}</span>
+            {status.latest?.htmlUrl && (
+              <a
+                className={styles.releaseLink}
+                href={status.latest.htmlUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Download and import manually
+              </a>
+            )}
+          </>
+        )}
+      </div>
+
+      <div className={styles.actions}>
+        {status.phase === 'available' && (
+          <>
+            <button className={styles.primaryButton} onClick={startUpdate}>
+              <Download size={14} />
+              Update now
+            </button>
+            <button className={styles.secondaryButton} onClick={dismiss}>
+              Later
+            </button>
+          </>
+        )}
+
+        {status.phase === 'done' && (
+          <button className={styles.primaryButton} onClick={() => window.location.reload()}>
+            <RefreshCw size={14} />
+            Reload
+          </button>
+        )}
+      </div>
+
+      {/* Downloading / importing are non-cancellable; hide the close button then. */}
+      {status.phase !== 'downloading' && status.phase !== 'importing' && (
+        <button className={styles.closeButton} onClick={dismiss} aria-label="Dismiss">
+          <X size={16} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -314,5 +314,44 @@ export const CARDINALITY_SYMBOLS: Record<string, { from: string; to: string }> =
   'N:N': { from: 'N', to: 'N' },
 };
 
+// =============================================================================
+// AUTO-UPDATE CONSTANTS
+// =============================================================================
+// Configuration for the "check for updates" feature that compares the installed
+// app version against the latest GitHub release and can import the managed
+// solution into the current Dataverse environment.
+
+/** GitHub repository owner that hosts the releases */
+export const GITHUB_OWNER = 'allandecastro';
+
+/** GitHub repository name that hosts the releases */
+export const GITHUB_REPO = 'dataverse-erd-visualizer';
+
+/** Unique name of the Dataverse solution shipped by this project */
+export const SOLUTION_UNIQUE_NAME = 'DataverseERDVisualizer';
+
+/**
+ * Base URL of the GitHub Pages site that hosts the per-version update payloads
+ * (`/update/v<version>.js`). Loading these via a dynamic <script> tag bypasses
+ * CORS entirely, unlike downloading the binary release asset.
+ */
+export const GITHUB_PAGES_BASE_URL = 'https://allandecastro.github.io/dataverse-erd-visualizer';
+
+/** Suffix of the managed solution asset attached to each GitHub release */
+export const MANAGED_ASSET_SUFFIX = '_managed.zip';
+
+/**
+ * Optional CORS proxy prefix for downloading the release asset binary.
+ * Leave empty to fetch GitHub directly. When set, the asset URL is appended to
+ * this value (e.g. 'https://my-proxy.example.com/?url=').
+ */
+export const UPDATE_PROXY_URL = '';
+
+/** localStorage key: whether the app checks for updates on load */
+export const UPDATE_CHECK_ENABLED_KEY = 'erd-update-check-enabled';
+
+/** localStorage key: the latest version the user explicitly dismissed */
+export const UPDATE_DISMISSED_VERSION_KEY = 'erd-update-dismissed-version';
+
 // SVG Logo as data URL (for Dataverse web resource compatibility)
 export const LOGO_DATA_URL = `data:image/svg+xml,${encodeURIComponent(`<svg width="400" height="400" viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="dvGrad" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" style="stop-color:rgb(236, 72, 153)"/><stop offset="100%" style="stop-color:rgb(139, 92, 246)"/></linearGradient><clipPath id="logoClip"><rect x="0" y="0" width="400" height="400" rx="40"/></clipPath></defs><g clip-path="url(#logoClip)"><rect x="0" y="0" width="400" height="400" rx="40" fill="url(#dvGrad)"/><rect x="60" y="60" width="100" height="80" rx="8" fill="#ffffff"/><rect x="60" y="60" width="100" height="24" rx="8" fill="#1e1b4b"/><line x1="70" y1="98" x2="140" y2="98" stroke="#6b7280" stroke-width="2" stroke-linecap="round"/><line x1="70" y1="114" x2="130" y2="114" stroke="#6b7280" stroke-width="2" stroke-linecap="round"/><line x1="70" y1="130" x2="120" y2="130" stroke="#6b7280" stroke-width="2" stroke-linecap="round"/><rect x="240" y="60" width="100" height="80" rx="8" fill="#ffffff"/><rect x="240" y="60" width="100" height="24" rx="8" fill="#1e1b4b"/><line x1="250" y1="98" x2="320" y2="98" stroke="#6b7280" stroke-width="2" stroke-linecap="round"/><line x1="250" y1="114" x2="310" y2="114" stroke="#6b7280" stroke-width="2" stroke-linecap="round"/><line x1="250" y1="130" x2="300" y2="130" stroke="#6b7280" stroke-width="2" stroke-linecap="round"/><rect x="150" y="200" width="100" height="80" rx="8" fill="#ffffff"/><rect x="150" y="200" width="100" height="24" rx="8" fill="#1e1b4b"/><line x1="160" y1="238" x2="230" y2="238" stroke="#6b7280" stroke-width="2" stroke-linecap="round"/><line x1="160" y1="254" x2="220" y2="254" stroke="#6b7280" stroke-width="2" stroke-linecap="round"/><line x1="160" y1="270" x2="210" y2="270" stroke="#6b7280" stroke-width="2" stroke-linecap="round"/><path d="M 160 100 L 240 100" stroke="#fbbf24" stroke-width="4" fill="none"/><path d="M 110 140 L 110 170 L 175 200" stroke="#fbbf24" stroke-width="4" fill="none"/><path d="M 290 140 L 290 170 L 225 200" stroke="#fbbf24" stroke-width="4" fill="none"/><circle cx="160" cy="100" r="6" fill="#fbbf24"/><circle cx="240" cy="100" r="6" fill="#fbbf24"/><circle cx="110" cy="140" r="6" fill="#fbbf24"/><circle cx="175" cy="200" r="6" fill="#fbbf24"/><circle cx="290" cy="140" r="6" fill="#fbbf24"/><circle cx="225" cy="200" r="6" fill="#fbbf24"/></g></svg>`)}`;

--- a/src/hooks/__tests__/useUpdateCheck.test.tsx
+++ b/src/hooks/__tests__/useUpdateCheck.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * Tests for useUpdateCheck — the auto-update orchestration hook.
+ * Services are mocked so we exercise the state machine (check-on-mount,
+ * download → import → poll, and error handling) in isolation.
+ * Note: the build-time global __APP_VERSION__ is defined as '0.0.0' in vitest.config.ts.
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useUpdateCheck } from '../useUpdateCheck';
+import type { LatestRelease } from '@/services/githubReleaseService';
+import { getLatestRelease, getManagedSolutionBase64 } from '@/services/githubReleaseService';
+import { dataverseApi, SolutionImportForbiddenError } from '@/services/dataverseApi';
+import {
+  getUpdateCheckEnabled,
+  getDismissedVersion,
+  setDismissedVersion,
+} from '@/services/updatePreferences';
+
+// Keep the real version-comparison logic, mock only the network entry points.
+vi.mock('@/services/githubReleaseService', async () => {
+  const actual = (await vi.importActual('@/services/githubReleaseService')) as Record<
+    string,
+    unknown
+  >;
+  return {
+    ...actual,
+    getLatestRelease: vi.fn(),
+    getManagedSolutionBase64: vi.fn(),
+  };
+});
+
+vi.mock('@/services/updatePreferences', () => ({
+  getUpdateCheckEnabled: vi.fn(() => true),
+  getDismissedVersion: vi.fn(() => null),
+  setDismissedVersion: vi.fn(),
+}));
+
+vi.mock('@/services/dataverseApi', async () => {
+  const actual = (await vi.importActual('@/services/dataverseApi')) as Record<string, unknown>;
+  return {
+    SolutionImportForbiddenError: actual.SolutionImportForbiddenError,
+    dataverseApi: {
+      isInDataverseContext: vi.fn(() => true),
+      importSolutionAsync: vi.fn(),
+      getAsyncOperationStatus: vi.fn(),
+      getImportJobProgress: vi.fn(),
+    },
+  };
+});
+
+const releaseV1: LatestRelease = {
+  tagName: 'v1.0.0.0',
+  version: '1.0.0.0',
+  htmlUrl: 'https://github.com/x/y/releases/tag/v1.0.0.0',
+  managedAsset: {
+    apiUrl: 'https://api.github.com/assets/2',
+    browserDownloadUrl: 'https://github.com/x/y/managed.zip',
+    name: 'DataverseERDVisualizer_1.0.0.0_managed.zip',
+    size: 10,
+  },
+};
+
+const mockGetLatestRelease = vi.mocked(getLatestRelease);
+const mockGetSolution = vi.mocked(getManagedSolutionBase64);
+const mockGetUpdateCheckEnabled = vi.mocked(getUpdateCheckEnabled);
+const mockGetDismissedVersion = vi.mocked(getDismissedVersion);
+const mockSetDismissedVersion = vi.mocked(setDismissedVersion);
+const mockImport = vi.mocked(dataverseApi.importSolutionAsync);
+const mockAsyncStatus = vi.mocked(dataverseApi.getAsyncOperationStatus);
+const mockProgress = vi.mocked(dataverseApi.getImportJobProgress);
+const mockIsInContext = vi.mocked(dataverseApi.isInDataverseContext);
+
+describe('useUpdateCheck', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUpdateCheckEnabled.mockReturnValue(true);
+    mockGetDismissedVersion.mockReturnValue(null);
+    mockIsInContext.mockReturnValue(true);
+  });
+
+  describe('check on mount', () => {
+    it('stays idle and skips the network when checks are disabled', async () => {
+      mockGetUpdateCheckEnabled.mockReturnValue(false);
+
+      const { result } = renderHook(() => useUpdateCheck());
+
+      expect(result.current.status.phase).toBe('idle');
+      expect(mockGetLatestRelease).not.toHaveBeenCalled();
+    });
+
+    it('surfaces an available update when a newer release exists', async () => {
+      mockGetLatestRelease.mockResolvedValue(releaseV1);
+
+      const { result } = renderHook(() => useUpdateCheck());
+
+      await waitFor(() => expect(result.current.status.phase).toBe('available'));
+      if (result.current.status.phase === 'available') {
+        expect(result.current.status.current).toBe('0.0.0');
+        expect(result.current.status.latest.version).toBe('1.0.0.0');
+      }
+    });
+
+    it('reports up to date when the latest release is not newer', async () => {
+      mockGetLatestRelease.mockResolvedValue({ ...releaseV1, version: '0.0.0' });
+
+      const { result } = renderHook(() => useUpdateCheck());
+
+      await waitFor(() => expect(result.current.status.phase).toBe('upToDate'));
+    });
+
+    it('does not prompt for a version the user dismissed', async () => {
+      mockGetDismissedVersion.mockReturnValue('1.0.0.0');
+      mockGetLatestRelease.mockResolvedValue(releaseV1);
+
+      const { result } = renderHook(() => useUpdateCheck());
+
+      await waitFor(() => expect(result.current.status.phase).toBe('upToDate'));
+    });
+
+    it('stays silent when the check itself fails', async () => {
+      mockGetLatestRelease.mockRejectedValue(new Error('network down'));
+
+      const { result } = renderHook(() => useUpdateCheck());
+
+      await waitFor(() => expect(result.current.status.phase).toBe('idle'));
+    });
+  });
+
+  describe('dismiss', () => {
+    it('remembers the version only when dismissing an available update', async () => {
+      mockGetLatestRelease.mockResolvedValue(releaseV1);
+      const { result } = renderHook(() => useUpdateCheck());
+      await waitFor(() => expect(result.current.status.phase).toBe('available'));
+
+      act(() => result.current.dismiss());
+
+      expect(mockSetDismissedVersion).toHaveBeenCalledWith('1.0.0.0');
+      expect(result.current.status.phase).toBe('idle');
+    });
+  });
+
+  describe('startUpdate', () => {
+    it('downloads, imports and reaches "done" on success', async () => {
+      vi.useFakeTimers();
+      try {
+        mockGetLatestRelease.mockResolvedValue(releaseV1);
+        mockGetSolution.mockResolvedValue('BASE64ZIP');
+        mockImport.mockResolvedValue({ asyncOperationId: 'async-1', importJobId: 'job-1' });
+        mockProgress.mockResolvedValue(100);
+        mockAsyncStatus.mockResolvedValue({ stateCode: 3, statusCode: 30 });
+
+        const { result } = renderHook(() => useUpdateCheck());
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
+        expect(result.current.status.phase).toBe('available');
+
+        await act(async () => {
+          const promise = result.current.startUpdate();
+          await vi.advanceTimersByTimeAsync(3000);
+          await promise;
+        });
+
+        expect(mockGetSolution).toHaveBeenCalledWith(releaseV1);
+        expect(mockImport).toHaveBeenCalledWith('BASE64ZIP');
+        expect(result.current.status.phase).toBe('done');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('reports an admin-privilege error when the import is forbidden', async () => {
+      mockGetLatestRelease.mockResolvedValue(releaseV1);
+      mockGetSolution.mockResolvedValue('BASE64ZIP');
+      mockImport.mockRejectedValue(new SolutionImportForbiddenError());
+
+      const { result } = renderHook(() => useUpdateCheck());
+      await waitFor(() => expect(result.current.status.phase).toBe('available'));
+
+      await act(async () => {
+        await result.current.startUpdate();
+      });
+
+      expect(result.current.status.phase).toBe('error');
+      if (result.current.status.phase === 'error') {
+        expect(result.current.status.message).toMatch(/System Administrator/);
+      }
+    });
+
+    it('errors before importing when outside a Dataverse context', async () => {
+      mockGetLatestRelease.mockResolvedValue(releaseV1);
+      mockIsInContext.mockReturnValue(false);
+
+      const { result } = renderHook(() => useUpdateCheck());
+      await waitFor(() => expect(result.current.status.phase).toBe('available'));
+
+      await act(async () => {
+        await result.current.startUpdate();
+      });
+
+      expect(result.current.status.phase).toBe('error');
+      expect(mockImport).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/useUpdateCheck.ts
+++ b/src/hooks/useUpdateCheck.ts
@@ -1,0 +1,166 @@
+/**
+ * useUpdateCheck
+ * Checks GitHub for a newer release on load and orchestrates the download +
+ * in-place import of the managed solution into the current Dataverse environment.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  getLatestRelease,
+  isUpdateAvailable,
+  getManagedSolutionBase64,
+  type LatestRelease,
+} from '@/services/githubReleaseService';
+import { dataverseApi, SolutionImportForbiddenError } from '@/services/dataverseApi';
+import {
+  getUpdateCheckEnabled,
+  getDismissedVersion,
+  setDismissedVersion,
+} from '@/services/updatePreferences';
+
+export type UpdateStatus =
+  | { phase: 'idle' }
+  | { phase: 'checking' }
+  | { phase: 'upToDate' }
+  | { phase: 'available'; current: string; latest: LatestRelease }
+  | { phase: 'downloading'; latest: LatestRelease }
+  | { phase: 'importing'; latest: LatestRelease; progress: number | null }
+  | { phase: 'done'; latest: LatestRelease }
+  | { phase: 'error'; message: string; latest?: LatestRelease };
+
+/** How often to poll the async import operation (ms) */
+const POLL_INTERVAL_MS = 3000;
+/** Safety cap on polling attempts (~10 min at 3s) */
+const MAX_POLL_ATTEMPTS = 200;
+
+/** statecode 3 = Completed */
+const ASYNC_STATE_COMPLETED = 3;
+/** statuscode 30 = Succeeded */
+const ASYNC_STATUS_SUCCEEDED = 30;
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export function useUpdateCheck() {
+  // Start in "checking" when enabled so the first render already reflects the
+  // pending check without a synchronous setState inside the effect.
+  const [status, setStatus] = useState<UpdateStatus>(() =>
+    getUpdateCheckEnabled() ? { phase: 'checking' } : { phase: 'idle' }
+  );
+  const hasCheckedRef = useRef(false);
+  const isUpdatingRef = useRef(false);
+
+  // Run the version check once on mount.
+  useEffect(() => {
+    if (hasCheckedRef.current) return;
+    hasCheckedRef.current = true;
+
+    if (!getUpdateCheckEnabled()) return;
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const latest = await getLatestRelease();
+        if (cancelled) return;
+
+        const current = __APP_VERSION__;
+        const dismissed = getDismissedVersion();
+
+        if (isUpdateAvailable(current, latest.version) && latest.version !== dismissed) {
+          setStatus({ phase: 'available', current, latest });
+        } else {
+          setStatus({ phase: 'upToDate' });
+        }
+      } catch {
+        // A failed check should stay silent — never block the app on the network.
+        if (!cancelled) setStatus({ phase: 'idle' });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  /** Download the managed solution and import it in place. */
+  const startUpdate = useCallback(async () => {
+    if (isUpdatingRef.current) return;
+    if (status.phase !== 'available') return;
+    const { latest } = status;
+
+    if (!dataverseApi.isInDataverseContext()) {
+      setStatus({
+        phase: 'error',
+        message: 'Updating requires running inside a Dataverse environment.',
+        latest,
+      });
+      return;
+    }
+
+    isUpdatingRef.current = true;
+    try {
+      // 1. Fetch the managed solution zip as base64 (Pages script include first,
+      //    then a direct binary download fallback).
+      setStatus({ phase: 'downloading', latest });
+      const base64 = await getManagedSolutionBase64(latest);
+
+      // 2. Start the async import.
+      setStatus({ phase: 'importing', latest, progress: null });
+      const { asyncOperationId, importJobId } = await dataverseApi.importSolutionAsync(base64);
+
+      // 3. Poll until the async operation completes.
+      for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
+        await delay(POLL_INTERVAL_MS);
+
+        const progress = importJobId ? await dataverseApi.getImportJobProgress(importJobId) : null;
+        setStatus({ phase: 'importing', latest, progress });
+
+        if (!asyncOperationId) continue;
+
+        const op = await dataverseApi.getAsyncOperationStatus(asyncOperationId);
+        if (op.stateCode === ASYNC_STATE_COMPLETED) {
+          if (op.statusCode === ASYNC_STATUS_SUCCEEDED) {
+            setStatus({ phase: 'done', latest });
+          } else {
+            setStatus({
+              phase: 'error',
+              message: op.message || 'The solution import did not complete successfully.',
+              latest,
+            });
+          }
+          return;
+        }
+      }
+
+      setStatus({
+        phase: 'error',
+        message: 'The solution import is taking longer than expected. Check the environment.',
+        latest,
+      });
+    } catch (error) {
+      const message =
+        error instanceof SolutionImportForbiddenError
+          ? error.message
+          : error instanceof Error
+            ? error.message
+            : 'The update failed. You can download and import the solution manually.';
+      setStatus({ phase: 'error', message, latest });
+    } finally {
+      isUpdatingRef.current = false;
+    }
+  }, [status]);
+
+  /**
+   * Dismiss the banner. Only an explicit "Later" on an available update is
+   * remembered — closing an error is not persisted, so a failed attempt still
+   * re-prompts on the next load (letting the user retry).
+   */
+  const dismiss = useCallback(() => {
+    if (status.phase === 'available') {
+      setDismissedVersion(status.latest.version);
+    }
+    setStatus({ phase: 'idle' });
+  }, [status]);
+
+  return { status, startUpdate, dismiss };
+}

--- a/src/services/__tests__/dataverseApiImport.test.ts
+++ b/src/services/__tests__/dataverseApiImport.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for the solution-import methods on DataverseApiService.
+ * Covers async import start (success / forbidden / error), status polling, and
+ * import-job progress reads.
+ */
+
+import { dataverseApi, SolutionImportForbiddenError } from '../dataverseApi';
+
+const mockFetch = vi.fn();
+
+describe('DataverseApiService — solution import', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+    // A Dataverse context is provided globally by the test setup (Xrm stub).
+  });
+
+  describe('importSolutionAsync', () => {
+    it('posts the base64 payload and returns the async + import job ids', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          AsyncOperationId: 'async-1',
+          ImportJobKey: 'job-1',
+        }),
+      });
+
+      const result = await dataverseApi.importSolutionAsync('QkFTRTY0');
+
+      expect(result).toEqual({ asyncOperationId: 'async-1', importJobId: 'job-1' });
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toContain('/ImportSolutionAsync');
+      expect(options.method).toBe('POST');
+      const body = JSON.parse(options.body);
+      expect(body.CustomizationFile).toBe('QkFTRTY0');
+      expect(body.OverwriteUnmanagedCustomizations).toBe(false);
+      expect(body.PublishWorkflows).toBe(true);
+      expect(body.ImportJobId).toBeTruthy();
+    });
+
+    it('falls back to the generated import job id when the response omits ImportJobKey', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ AsyncOperationId: 'async-2' }),
+      });
+
+      const result = await dataverseApi.importSolutionAsync('x');
+      expect(result.asyncOperationId).toBe('async-2');
+      // Import job id defaults to the client-generated GUID sent in the request.
+      const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(result.importJobId).toBe(sentBody.ImportJobId);
+    });
+
+    it('throws SolutionImportForbiddenError on HTTP 403', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 403, statusText: 'Forbidden' });
+
+      await expect(dataverseApi.importSolutionAsync('x')).rejects.toBeInstanceOf(
+        SolutionImportForbiddenError
+      );
+    });
+
+    it('throws with the server message on other failures', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Server Error',
+        json: async () => ({ error: { message: 'Boom' } }),
+      });
+
+      await expect(dataverseApi.importSolutionAsync('x')).rejects.toThrow(/Boom/);
+    });
+  });
+
+  describe('getAsyncOperationStatus', () => {
+    it('maps statecode/statuscode/message', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ statecode: 3, statuscode: 30, message: undefined }),
+      });
+
+      const status = await dataverseApi.getAsyncOperationStatus('async-1');
+      expect(status).toEqual({ stateCode: 3, statusCode: 30, message: undefined });
+    });
+
+    it('throws on a failed status read', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        json: async () => ({}),
+      });
+
+      await expect(dataverseApi.getAsyncOperationStatus('async-1')).rejects.toThrow(
+        /404|Not Found/
+      );
+    });
+  });
+
+  describe('getImportJobProgress', () => {
+    it('returns the numeric progress', async () => {
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ progress: 42.5 }) });
+      await expect(dataverseApi.getImportJobProgress('job-1')).resolves.toBe(42.5);
+    });
+
+    it('returns null when the import job cannot be read yet', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' });
+      await expect(dataverseApi.getImportJobProgress('job-1')).resolves.toBeNull();
+    });
+
+    it('returns null on a network error', async () => {
+      mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
+      await expect(dataverseApi.getImportJobProgress('job-1')).resolves.toBeNull();
+    });
+  });
+});

--- a/src/services/__tests__/githubReleaseService.test.ts
+++ b/src/services/__tests__/githubReleaseService.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Tests for the GitHub Release Service
+ * Covers version comparison, update detection, and release parsing.
+ */
+
+import {
+  compareVersions,
+  isUpdateAvailable,
+  getLatestRelease,
+  downloadManagedSolutionBase64,
+  fetchManagedSolutionFromPages,
+  loadManagedSolutionViaScript,
+  getManagedSolutionBase64,
+  type ReleaseAsset,
+  type LatestRelease,
+} from '../githubReleaseService';
+
+const mockFetch = vi.fn();
+
+const asset: ReleaseAsset = {
+  apiUrl: 'https://api.github.com/assets/2',
+  browserDownloadUrl: 'https://github.com/x/y/releases/download/managed.zip',
+  name: 'DataverseERDVisualizer_0.1.13.0_managed.zip',
+  size: 3,
+};
+
+/** Build a fake ok/failed Response whose body is the given bytes. */
+function bytesResponse(ok: boolean, bytes = new Uint8Array([0x50, 0x4b, 0x03])) {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    statusText: ok ? 'OK' : 'Server Error',
+    arrayBuffer: async () => bytes.buffer,
+  };
+}
+
+describe('githubReleaseService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+  });
+
+  describe('compareVersions', () => {
+    it('treats equal 4-segment versions as equal', () => {
+      expect(compareVersions('0.1.12.4', '0.1.12.4')).toBe(0);
+    });
+
+    it('detects a newer patch segment', () => {
+      expect(compareVersions('0.1.12.5', '0.1.12.4')).toBeGreaterThan(0);
+      expect(compareVersions('0.1.12.4', '0.1.12.5')).toBeLessThan(0);
+    });
+
+    it('compares major/minor before later segments', () => {
+      expect(compareVersions('1.0.0.0', '0.9.99.99')).toBeGreaterThan(0);
+      expect(compareVersions('0.2.0.0', '0.1.99.99')).toBeGreaterThan(0);
+    });
+
+    it('pads missing segments with zero', () => {
+      expect(compareVersions('0.1.12', '0.1.12.0')).toBe(0);
+      expect(compareVersions('0.1.12.1', '0.1.12')).toBeGreaterThan(0);
+    });
+
+    it('ignores a leading "v"', () => {
+      expect(compareVersions('v0.1.12.4', '0.1.12.4')).toBe(0);
+    });
+
+    it('treats non-numeric segments as zero', () => {
+      expect(compareVersions('0.1.x.4', '0.1.0.4')).toBe(0);
+    });
+  });
+
+  describe('isUpdateAvailable', () => {
+    it('is true only when the latest version is strictly newer', () => {
+      expect(isUpdateAvailable('0.1.12.4', '0.1.12.5')).toBe(true);
+      expect(isUpdateAvailable('0.1.12.4', '0.1.12.4')).toBe(false);
+      expect(isUpdateAvailable('0.1.12.5', '0.1.12.4')).toBe(false);
+    });
+  });
+
+  describe('getLatestRelease', () => {
+    it('parses the tag and selects the managed solution asset', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          tag_name: 'v0.1.13.0',
+          html_url:
+            'https://github.com/allandecastro/dataverse-erd-visualizer/releases/tag/v0.1.13.0',
+          assets: [
+            {
+              name: 'webresources_0.1.13.0.zip',
+              url: 'https://api.github.com/assets/1',
+              browser_download_url: 'https://github.com/.../webresources_0.1.13.0.zip',
+              size: 1000,
+            },
+            {
+              name: 'DataverseERDVisualizer_0.1.13.0_managed.zip',
+              url: 'https://api.github.com/assets/2',
+              browser_download_url: 'https://github.com/.../managed.zip',
+              size: 2000,
+            },
+          ],
+        }),
+      });
+
+      const release = await getLatestRelease();
+
+      expect(release.tagName).toBe('v0.1.13.0');
+      expect(release.version).toBe('0.1.13.0');
+      expect(release.managedAsset).not.toBeNull();
+      expect(release.managedAsset?.name).toBe('DataverseERDVisualizer_0.1.13.0_managed.zip');
+      expect(release.managedAsset?.apiUrl).toBe('https://api.github.com/assets/2');
+    });
+
+    it('returns a null managed asset when none is attached', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          tag_name: 'v0.1.13.0',
+          html_url: 'https://github.com/x/y/releases/tag/v0.1.13.0',
+          assets: [
+            {
+              name: 'webresources_0.1.13.0.zip',
+              url: 'https://api.github.com/assets/1',
+              browser_download_url: 'https://github.com/.../webresources_0.1.13.0.zip',
+              size: 1000,
+            },
+          ],
+        }),
+      });
+
+      const release = await getLatestRelease();
+      expect(release.managedAsset).toBeNull();
+    });
+
+    it('throws when the GitHub API responds with an error', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+      await expect(getLatestRelease()).rejects.toThrow(/404/);
+    });
+  });
+
+  describe('downloadManagedSolutionBase64', () => {
+    it('downloads via the api endpoint and returns base64', async () => {
+      mockFetch.mockResolvedValueOnce(bytesResponse(true, new Uint8Array([0x50, 0x4b])));
+
+      const base64 = await downloadManagedSolutionBase64(asset);
+
+      // 0x50,0x4b === "PK" === base64 "UEs"
+      expect(base64).toBe('UEs=');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        asset.apiUrl,
+        expect.objectContaining({ headers: { Accept: 'application/octet-stream' } })
+      );
+    });
+
+    it('falls back to the browser download URL when the primary fetch fails (CORS)', async () => {
+      mockFetch
+        .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+        .mockResolvedValueOnce(bytesResponse(true, new Uint8Array([0x50, 0x4b])));
+
+      const base64 = await downloadManagedSolutionBase64(asset);
+
+      expect(base64).toBe('UEs=');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenLastCalledWith(asset.browserDownloadUrl, expect.anything());
+    });
+
+    it('throws when every download strategy fails', async () => {
+      mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
+
+      await expect(downloadManagedSolutionBase64(asset)).rejects.toThrow(/Failed to fetch/);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('loadManagedSolutionViaScript', () => {
+    afterEach(() => {
+      delete window.__ERD_SOLUTION_UPDATE__;
+      document.head.querySelectorAll('script[src*="/update/"]').forEach((s) => s.remove());
+    });
+
+    /** Grab the injected update script for a given version. */
+    const injectedScript = (version: string) =>
+      document.head.querySelector<HTMLScriptElement>(`script[src$="/update/v${version}.js"]`);
+
+    it('resolves with the base64 payload once the script populates the global', async () => {
+      const promise = loadManagedSolutionViaScript('1.0.0.0');
+      const script = injectedScript('1.0.0.0');
+      expect(script).toBeTruthy();
+
+      window.__ERD_SOLUTION_UPDATE__ = { version: '1.0.0.0', data: 'PAYLOAD64' };
+      script!.dispatchEvent(new Event('load'));
+
+      await expect(promise).resolves.toBe('PAYLOAD64');
+      // Global and script are cleaned up afterwards.
+      expect(window.__ERD_SOLUTION_UPDATE__).toBeUndefined();
+    });
+
+    it('rejects when the script fails to load', async () => {
+      const promise = loadManagedSolutionViaScript('1.0.0.0');
+      injectedScript('1.0.0.0')!.dispatchEvent(new Event('error'));
+      await expect(promise).rejects.toThrow(/Failed to load/);
+    });
+
+    it('rejects when the payload version does not match', async () => {
+      const promise = loadManagedSolutionViaScript('1.0.0.0');
+      window.__ERD_SOLUTION_UPDATE__ = { version: '9.9.9.9', data: 'X' };
+      injectedScript('1.0.0.0')!.dispatchEvent(new Event('load'));
+      await expect(promise).rejects.toThrow(/did not match the expected version/);
+    });
+  });
+
+  describe('fetchManagedSolutionFromPages', () => {
+    it('returns the base64 from the Pages JSON payload', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ version: '1.0.0.0', data: 'VIAFETCH' }),
+      });
+
+      await expect(fetchManagedSolutionFromPages('1.0.0.0')).resolves.toBe('VIAFETCH');
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://allandecastro.github.io/dataverse-erd-visualizer/update/v1.0.0.0.json',
+        expect.anything()
+      );
+    });
+
+    it('throws when the payload is not available (404)', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 404 });
+      await expect(fetchManagedSolutionFromPages('1.0.0.0')).rejects.toThrow(/not available/);
+    });
+
+    it('throws when the payload version does not match', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ version: '9.9.9.9', data: 'X' }),
+      });
+      await expect(fetchManagedSolutionFromPages('1.0.0.0')).rejects.toThrow(
+        /did not match the expected version/
+      );
+    });
+  });
+
+  describe('getManagedSolutionBase64', () => {
+    const release: LatestRelease = {
+      tagName: 'v1.0.0.0',
+      version: '1.0.0.0',
+      htmlUrl: 'https://github.com/x/y/releases/tag/v1.0.0.0',
+      managedAsset: asset,
+    };
+
+    afterEach(() => {
+      delete window.__ERD_SOLUTION_UPDATE__;
+      document.head.querySelectorAll('script[src*="/update/"]').forEach((s) => s.remove());
+    });
+
+    /** Wait (microtask poll) for the update script to be injected, then return it. */
+    const waitForScript = async (version: string): Promise<HTMLScriptElement> => {
+      for (let i = 0; i < 100; i++) {
+        const el = document.head.querySelector<HTMLScriptElement>(
+          `script[src$="/update/v${version}.js"]`
+        );
+        if (el) return el;
+        await Promise.resolve();
+      }
+      throw new Error('update script was never injected');
+    };
+
+    it('prefers the data-only Pages fetch (no script injected)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ version: '1.0.0.0', data: 'VIAFETCH' }),
+      });
+
+      await expect(getManagedSolutionBase64(release)).resolves.toBe('VIAFETCH');
+      expect(document.head.querySelector('script[src*="/update/"]')).toBeNull();
+    });
+
+    it('falls back to the <script> include when the fetch fails', async () => {
+      mockFetch.mockRejectedValueOnce(new TypeError('connect-src blocked'));
+
+      const promise = getManagedSolutionBase64(release);
+      const script = await waitForScript('1.0.0.0');
+      window.__ERD_SOLUTION_UPDATE__ = { version: '1.0.0.0', data: 'VIASCRIPT' };
+      script.dispatchEvent(new Event('load'));
+
+      await expect(promise).resolves.toBe('VIASCRIPT');
+    });
+
+    it('falls back to the binary download when both Pages strategies fail', async () => {
+      mockFetch
+        .mockRejectedValueOnce(new TypeError('connect-src blocked')) // Pages JSON fetch
+        .mockResolvedValueOnce(bytesResponse(true, new Uint8Array([0x50, 0x4b]))); // asset download
+
+      const promise = getManagedSolutionBase64(release);
+      const script = await waitForScript('1.0.0.0');
+      script.dispatchEvent(new Event('error'));
+
+      await expect(promise).resolves.toBe('UEs=');
+    });
+  });
+});

--- a/src/services/dataverseApi.ts
+++ b/src/services/dataverseApi.ts
@@ -39,6 +39,44 @@ interface DataverseSolutionComponentResponse {
   _solutionid_value: string;
 }
 
+/** Result of starting an asynchronous solution import */
+export interface ImportSolutionResult {
+  asyncOperationId: string;
+  importJobId: string;
+}
+
+/** Status of an in-flight async solution import */
+export interface AsyncOperationStatus {
+  /** statecode: 0=Ready, 1=Suspended, 2=Locked, 3=Completed */
+  stateCode: number;
+  /** statuscode: 30=Succeeded, 31/32=Failed/Canceled, etc. */
+  statusCode: number;
+  /** Friendly message (populated on failure) */
+  message?: string;
+}
+
+/** Error raised when the current user lacks import privileges */
+export class SolutionImportForbiddenError extends Error {
+  constructor(message = 'Importing a solution requires System Administrator privileges.') {
+    super(message);
+    this.name = 'SolutionImportForbiddenError';
+  }
+}
+
+/** Generate an RFC-4122 v4 GUID (crypto-backed when available) */
+function generateGuid(): string {
+  const cryptoObj = typeof globalThis !== 'undefined' ? globalThis.crypto : undefined;
+  if (cryptoObj?.randomUUID) {
+    return cryptoObj.randomUUID();
+  }
+  // Fallback for older runtimes
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
 /** Raw attribute response from Dataverse API */
 interface DataverseAttributeResponse {
   '@odata.type'?: string;
@@ -83,6 +121,20 @@ class DataverseApiService {
 
     // Final fallback to current origin (development mode uses mock data anyway)
     return typeof window !== 'undefined' ? window.location.origin : '';
+  }
+
+  /**
+   * Standard OData/JSON headers for Dataverse Web API requests.
+   * @param extra - additional headers (e.g. a `Prefer` page-size hint)
+   */
+  private jsonHeaders(extra?: Record<string, string>): Record<string, string> {
+    return {
+      Accept: 'application/json',
+      'OData-MaxVersion': '4.0',
+      'OData-Version': '4.0',
+      'Content-Type': 'application/json',
+      ...extra,
+    };
   }
 
   /**
@@ -217,13 +269,7 @@ class DataverseApiService {
 
       const response = await fetch(url, {
         method: 'GET',
-        headers: {
-          Accept: 'application/json',
-          'OData-MaxVersion': '4.0',
-          'OData-Version': '4.0',
-          'Content-Type': 'application/json',
-          Prefer: 'odata.maxpagesize=100', // Request 100 entities per page
-        },
+        headers: this.jsonHeaders({ Prefer: 'odata.maxpagesize=100' }),
       });
 
       if (!response.ok) {
@@ -273,12 +319,7 @@ class DataverseApiService {
           const attributesQuery = `EntityDefinitions(LogicalName='${entityMeta.LogicalName}')/Attributes?$select=LogicalName,AttributeType,DisplayName,IsCustomAttribute,SourceType`;
           const attrResponse = await fetch(`${this.baseUrl}/${attributesQuery}`, {
             method: 'GET',
-            headers: {
-              Accept: 'application/json',
-              'OData-MaxVersion': '4.0',
-              'OData-Version': '4.0',
-              'Content-Type': 'application/json',
-            },
+            headers: this.jsonHeaders(),
           });
 
           // Get solution names for this entity
@@ -489,12 +530,7 @@ class DataverseApiService {
 
       const response = await fetch(url, {
         method: 'GET',
-        headers: {
-          Accept: 'application/json',
-          'OData-MaxVersion': '4.0',
-          'OData-Version': '4.0',
-          'Content-Type': 'application/json',
-        },
+        headers: this.jsonHeaders(),
       });
 
       if (!response.ok) {
@@ -534,13 +570,7 @@ class DataverseApiService {
       while (url) {
         const response = await fetch(url, {
           method: 'GET',
-          headers: {
-            Accept: 'application/json',
-            'OData-MaxVersion': '4.0',
-            'OData-Version': '4.0',
-            'Content-Type': 'application/json',
-            Prefer: 'odata.maxpagesize=5000',
-          },
+          headers: this.jsonHeaders({ Prefer: 'odata.maxpagesize=5000' }),
         });
 
         if (!response.ok) {
@@ -576,6 +606,112 @@ class DataverseApiService {
     } catch (error) {
       console.warn('Error fetching solution components:', error);
       return entitySolutionMap;
+    }
+  }
+
+  /**
+   * Start an asynchronous solution import (in-place update).
+   * The current user must have System Administrator / Customizer privileges.
+   *
+   * @param customizationFileBase64 - base64-encoded managed solution zip
+   * @throws SolutionImportForbiddenError when the user lacks privileges (403)
+   * @throws Error on other failures
+   */
+  async importSolutionAsync(customizationFileBase64: string): Promise<ImportSolutionResult> {
+    this.initialize();
+
+    const importJobId = generateGuid();
+    const body = {
+      OverwriteUnmanagedCustomizations: false,
+      PublishWorkflows: true,
+      CustomizationFile: customizationFileBase64,
+      ImportJobId: importJobId,
+    };
+
+    const response = await fetch(`${this.baseUrl}/ImportSolutionAsync`, {
+      method: 'POST',
+      headers: this.jsonHeaders(),
+      body: JSON.stringify(body),
+    });
+
+    if (response.status === 403) {
+      throw new SolutionImportForbiddenError();
+    }
+
+    if (!response.ok) {
+      const detail = await this.readErrorMessage(response);
+      throw new Error(`Failed to start solution import: ${detail}`);
+    }
+
+    const data: { AsyncOperationId?: string; ImportJobKey?: string } = await response.json();
+
+    return {
+      asyncOperationId: data.AsyncOperationId ?? '',
+      importJobId: data.ImportJobKey ?? importJobId,
+    };
+  }
+
+  /**
+   * Poll the status of an asynchronous operation (e.g. a solution import).
+   */
+  async getAsyncOperationStatus(asyncOperationId: string): Promise<AsyncOperationStatus> {
+    this.initialize();
+
+    const url = `${this.baseUrl}/asyncoperations(${asyncOperationId})?$select=statecode,statuscode,message`;
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: this.jsonHeaders(),
+    });
+
+    if (!response.ok) {
+      const detail = await this.readErrorMessage(response);
+      throw new Error(`Failed to read import status: ${detail}`);
+    }
+
+    const data: { statecode: number; statuscode: number; message?: string } = await response.json();
+
+    return {
+      stateCode: data.statecode,
+      statusCode: data.statuscode,
+      message: data.message,
+    };
+  }
+
+  /**
+   * Read the progress (0-100) of an import job, if available.
+   * Returns null when the job cannot be read yet.
+   */
+  async getImportJobProgress(importJobId: string): Promise<number | null> {
+    this.initialize();
+
+    try {
+      const url = `${this.baseUrl}/importjobs(${importJobId})?$select=progress`;
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: this.jsonHeaders(),
+      });
+
+      if (!response.ok) {
+        return null;
+      }
+
+      const data: { progress?: number } = await response.json();
+      return typeof data.progress === 'number' ? data.progress : null;
+    } catch {
+      // Import job row may not exist yet — treat as unknown progress.
+      return null;
+    }
+  }
+
+  /**
+   * Extract a human-readable message from a failed Dataverse Web API response.
+   */
+  private async readErrorMessage(response: Response): Promise<string> {
+    try {
+      const data: { error?: { message?: string } } = await response.json();
+      return data.error?.message || `${response.status} ${response.statusText}`;
+    } catch {
+      return `${response.status} ${response.statusText}`;
     }
   }
 }

--- a/src/services/githubReleaseService.ts
+++ b/src/services/githubReleaseService.ts
@@ -1,0 +1,319 @@
+/**
+ * GitHub Release Service
+ * Checks the latest published release on GitHub and downloads the managed
+ * solution asset so it can be imported into Dataverse. This is the only part of
+ * the app that talks to an external (non-Dataverse) host.
+ */
+
+import {
+  GITHUB_OWNER,
+  GITHUB_REPO,
+  GITHUB_PAGES_BASE_URL,
+  MANAGED_ASSET_SUFFIX,
+  UPDATE_PROXY_URL,
+} from '@/constants';
+
+/** Payload shape assigned by the published update script on GitHub Pages. */
+interface SolutionUpdatePayload {
+  version: string;
+  data: string; // base64 of the managed solution zip
+}
+
+declare global {
+  interface Window {
+    __ERD_SOLUTION_UPDATE__?: SolutionUpdatePayload;
+  }
+}
+
+/** A downloadable asset attached to a GitHub release */
+export interface ReleaseAsset {
+  /** api.github.com asset endpoint (best CORS compatibility with octet-stream) */
+  apiUrl: string;
+  /** Public browser download URL (fallback) */
+  browserDownloadUrl: string;
+  name: string;
+  size: number;
+}
+
+/** Parsed information about the latest GitHub release */
+export interface LatestRelease {
+  /** Raw git tag, e.g. "v0.1.12.4" */
+  tagName: string;
+  /** Version without the leading "v", e.g. "0.1.12.4" */
+  version: string;
+  /** Public release page URL */
+  htmlUrl: string;
+  /** The managed solution asset, if present */
+  managedAsset: ReleaseAsset | null;
+}
+
+/** Raw asset shape from the GitHub REST API */
+interface GitHubApiAsset {
+  url: string;
+  browser_download_url: string;
+  name: string;
+  size: number;
+}
+
+/** Raw release shape from the GitHub REST API */
+interface GitHubApiRelease {
+  tag_name: string;
+  html_url: string;
+  assets: GitHubApiAsset[];
+}
+
+const RELEASES_LATEST_URL = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/releases/latest`;
+
+/**
+ * Compare two 4-segment (Dataverse-style) version strings.
+ * Missing segments are treated as 0.
+ * @returns positive if a > b, negative if a < b, 0 if equal.
+ */
+export function compareVersions(a: string, b: string): number {
+  const parse = (v: string): number[] =>
+    v
+      .trim()
+      .replace(/^v/i, '')
+      .split('.')
+      .map((seg) => {
+        const n = parseInt(seg, 10);
+        return Number.isNaN(n) ? 0 : n;
+      });
+
+  const pa = parse(a);
+  const pb = parse(b);
+  const len = Math.max(pa.length, pb.length, 4);
+
+  for (let i = 0; i < len; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * Whether `latestVersion` is strictly newer than `currentVersion`.
+ */
+export function isUpdateAvailable(currentVersion: string, latestVersion: string): boolean {
+  return compareVersions(latestVersion, currentVersion) > 0;
+}
+
+/**
+ * Fetch the latest release metadata from GitHub.
+ * @throws Error when the network request fails or the response is not ok.
+ */
+export async function getLatestRelease(): Promise<LatestRelease> {
+  const response = await fetch(RELEASES_LATEST_URL, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/vnd.github+json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub API returned ${response.status} ${response.statusText}`);
+  }
+
+  const data: GitHubApiRelease = await response.json();
+  const tagName = data.tag_name ?? '';
+  const version = tagName.replace(/^v/i, '');
+
+  const managed = data.assets?.find((asset) => asset.name.endsWith(MANAGED_ASSET_SUFFIX));
+
+  return {
+    tagName,
+    version,
+    htmlUrl: data.html_url,
+    managedAsset: managed
+      ? {
+          apiUrl: managed.url,
+          browserDownloadUrl: managed.browser_download_url,
+          name: managed.name,
+          size: managed.size,
+        }
+      : null,
+  };
+}
+
+/**
+ * Convert an ArrayBuffer to a base64 string in chunks to avoid call-stack
+ * overflow on large payloads (managed solution zips can be several MB).
+ */
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000; // 32KB per chunk
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Download the managed solution asset and return it base64-encoded, ready to be
+ * passed as `CustomizationFile` to ImportSolution.
+ *
+ * Tries the api.github.com asset endpoint first (best CORS support), then falls
+ * back to the public browser download URL. An optional {@link UPDATE_PROXY_URL}
+ * can be configured to work around CORS restrictions on the binary download.
+ *
+ * @throws Error (typically a CORS/network TypeError) when the binary cannot be fetched.
+ */
+export async function downloadManagedSolutionBase64(asset: ReleaseAsset): Promise<string> {
+  const attempts: Array<{ url: string; headers: Record<string, string> }> = [];
+
+  const proxied = (url: string) => (UPDATE_PROXY_URL ? `${UPDATE_PROXY_URL}${url}` : url);
+
+  // Primary: api.github.com asset endpoint returns the binary with octet-stream.
+  attempts.push({
+    url: proxied(asset.apiUrl),
+    headers: { Accept: 'application/octet-stream' },
+  });
+  // Fallback: the public browser download URL.
+  attempts.push({
+    url: proxied(asset.browserDownloadUrl),
+    headers: {},
+  });
+
+  let lastError: unknown;
+  for (const attempt of attempts) {
+    try {
+      const response = await fetch(attempt.url, {
+        method: 'GET',
+        headers: attempt.headers,
+      });
+      if (!response.ok) {
+        lastError = new Error(`Download failed: ${response.status} ${response.statusText}`);
+        continue;
+      }
+      const buffer = await response.arrayBuffer();
+      return arrayBufferToBase64(buffer);
+    } catch (error) {
+      // Typically a CORS TypeError — try the next strategy.
+      lastError = error;
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error('Failed to download the managed solution asset');
+}
+
+/**
+ * Fetch the managed solution as base64 from the GitHub Pages JSON payload.
+ *
+ * GitHub Pages returns `Access-Control-Allow-Origin: *`, so a plain cross-origin
+ * `fetch` works from the Dataverse iframe — and unlike the <script> include this
+ * only retrieves data (no remote code execution). This is the preferred strategy.
+ *
+ * @throws Error when the payload is unavailable or its version does not match.
+ */
+export async function fetchManagedSolutionFromPages(version: string): Promise<string> {
+  const url = `${GITHUB_PAGES_BASE_URL}/update/v${version}.json`;
+  const response = await fetch(url, { headers: { Accept: 'application/json' } });
+  if (!response.ok) {
+    throw new Error(`Update payload not available on GitHub Pages: ${response.status}`);
+  }
+  const payload = (await response.json()) as Partial<SolutionUpdatePayload>;
+  if (!payload || payload.version !== version || !payload.data) {
+    throw new Error('The Pages payload was missing or did not match the expected version.');
+  }
+  return payload.data;
+}
+
+/** Timeout for loading the GitHub Pages update script (ms) */
+const SCRIPT_LOAD_TIMEOUT_MS = 30000;
+
+/**
+ * Load the managed solution as base64 by injecting a <script> from GitHub Pages.
+ *
+ * A cross-origin `<script>` tag is exempt from CORS, so this works from the
+ * Dataverse iframe where a direct binary `fetch` of the release asset is blocked.
+ * The script assigns `window.__ERD_SOLUTION_UPDATE__ = { version, data }`, which
+ * we read back, validate against the expected version, and then clean up.
+ *
+ * @param integrity - optional Subresource Integrity hash. Note: setting it turns
+ *   the request into CORS mode, so it only works if Pages returns an ACAO header.
+ * @throws Error on load failure, timeout, or a version/payload mismatch.
+ */
+export function loadManagedSolutionViaScript(version: string, integrity?: string): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const url = `${GITHUB_PAGES_BASE_URL}/update/v${version}.js`;
+    const script = document.createElement('script');
+    script.src = url;
+    if (integrity) {
+      script.integrity = integrity;
+      script.crossOrigin = 'anonymous';
+    }
+
+    let settled = false;
+    const cleanup = () => {
+      script.remove();
+      delete window.__ERD_SOLUTION_UPDATE__;
+    };
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error('Timed out loading the update payload from GitHub Pages.'));
+    }, SCRIPT_LOAD_TIMEOUT_MS);
+
+    script.onload = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      const payload = window.__ERD_SOLUTION_UPDATE__;
+      cleanup();
+      if (!payload || payload.version !== version || !payload.data) {
+        reject(new Error('The update payload was missing or did not match the expected version.'));
+        return;
+      }
+      resolve(payload.data);
+    };
+
+    script.onerror = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      cleanup();
+      reject(new Error('Failed to load the update payload from GitHub Pages.'));
+    };
+
+    document.head.appendChild(script);
+  });
+}
+
+/**
+ * Obtain the managed solution as base64 via a resilient cascade:
+ *   1. `fetch` the Pages JSON payload — safe (data-only) and CORS-OK.
+ *   2. `<script>` include of the Pages JS payload — CORS-exempt escape hatch if a
+ *      CSP allows `script-src` but blocks `connect-src`.
+ *   3. Direct binary download of the release asset — last resort (may hit CORS).
+ *
+ * @throws the last strategy's error when none succeed.
+ */
+export async function getManagedSolutionBase64(release: LatestRelease): Promise<string> {
+  const strategies: Array<() => Promise<string>> = [
+    () => fetchManagedSolutionFromPages(release.version),
+    () => loadManagedSolutionViaScript(release.version),
+  ];
+  const asset = release.managedAsset;
+  if (asset) {
+    strategies.push(() => downloadManagedSolutionBase64(asset));
+  }
+
+  let lastError: unknown;
+  for (const strategy of strategies) {
+    try {
+      return await strategy();
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error('Unable to retrieve the managed solution.');
+}

--- a/src/services/updatePreferences.ts
+++ b/src/services/updatePreferences.ts
@@ -1,0 +1,47 @@
+/**
+ * Update preferences — thin, dependency-free wrapper around the localStorage
+ * keys used by the auto-update feature. Kept separate from the hook so pure UI
+ * (e.g. the settings checkbox) can read/write the preference without importing
+ * the update/import machinery.
+ */
+
+import { UPDATE_CHECK_ENABLED_KEY, UPDATE_DISMISSED_VERSION_KEY } from '@/constants';
+
+/** Safely read a localStorage value, returning null on any failure. */
+function readItem(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/** Safely write a localStorage value, ignoring any failure. */
+function writeItem(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Ignore storage failures (private mode, quota, etc.).
+  }
+}
+
+/** Whether the app should check for updates on load (default: enabled). */
+export function getUpdateCheckEnabled(): boolean {
+  // Default to enabled unless explicitly turned off.
+  return readItem(UPDATE_CHECK_ENABLED_KEY) !== 'false';
+}
+
+/** Persist the "check for updates on load" preference. */
+export function setUpdateCheckEnabled(enabled: boolean): void {
+  writeItem(UPDATE_CHECK_ENABLED_KEY, enabled ? 'true' : 'false');
+}
+
+/** The release version the user last dismissed, if any. */
+export function getDismissedVersion(): string | null {
+  return readItem(UPDATE_DISMISSED_VERSION_KEY);
+}
+
+/** Remember a release version so its banner stops prompting. */
+export function setDismissedVersion(version: string): void {
+  writeItem(UPDATE_DISMISSED_VERSION_KEY, version);
+}

--- a/src/styles/UpdateBanner.module.css
+++ b/src/styles/UpdateBanner.module.css
@@ -1,0 +1,178 @@
+/**
+ * Update banner styles — persistent, dismissible bar shown at the top of the app
+ * when a newer release is available or an update is in progress.
+ */
+
+.banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10001;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 500;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.25);
+  animation: bannerSlideDown 0.3s ease-out;
+}
+
+.info {
+  background: linear-gradient(90deg, rgba(139, 92, 246, 0.97), rgba(236, 72, 153, 0.97));
+}
+
+.success {
+  background: rgba(16, 185, 129, 0.97);
+}
+
+.error {
+  background: rgba(239, 68, 68, 0.97);
+}
+
+.icon {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.message {
+  line-height: 1.3;
+}
+
+.releaseLink {
+  color: #ffffff;
+  text-decoration: underline;
+  opacity: 0.9;
+  font-size: 12px;
+  width: fit-content;
+}
+
+.releaseLink:hover {
+  opacity: 1;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.primaryButton,
+.secondaryButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition:
+    background-color 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.primaryButton {
+  background: #ffffff;
+  color: #1e1b4b;
+}
+
+.primaryButton:hover {
+  opacity: 0.9;
+}
+
+.secondaryButton {
+  background: rgba(255, 255, 255, 0.15);
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+.secondaryButton:hover {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.closeButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border-radius: 6px;
+  background: transparent;
+  border: none;
+  color: #ffffff;
+  cursor: pointer;
+  opacity: 0.85;
+  flex-shrink: 0;
+}
+
+.closeButton:hover {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.progressTrack {
+  height: 4px;
+  width: 100%;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.25);
+  overflow: hidden;
+  margin-top: 4px;
+}
+
+.progressBar {
+  height: 100%;
+  background: #ffffff;
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+
+.progressIndeterminate {
+  width: 40%;
+  animation: progressSlide 1.2s ease-in-out infinite;
+}
+
+.spinner {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes bannerSlideDown {
+  from {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes progressSlide {
+  0% {
+    margin-left: -40%;
+  }
+  100% {
+    margin-left: 100%;
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,10 @@ const __dirname = dirname(__filename);
 
 export default defineConfig({
   plugins: [react()],
+  // Provide the build-time global so modules referencing it can run under Vitest.
+  define: {
+    __APP_VERSION__: JSON.stringify('0.0.0'),
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## What

Adds an **auto-update** flow: on load the app checks the latest GitHub release, and when a newer version exists shows a banner. An admin can update in place — the managed solution is downloaded and imported via `ImportSolutionAsync` with async polling, all from inside the Dataverse web resource.

## How

- **Detection** — `getLatestRelease()` (GitHub API, CORS-OK) + 4-segment version compare vs `__APP_VERSION__`.
- **Download (CORS bypass cascade)** — `getManagedSolutionBase64()`:
  1. `fetch` the Pages JSON payload `update/v<version>.json` — data-only, safe (Pages sends `ACAO: *`).
  2. `<script>` include of `update/v<version>.js` — CORS-exempt escape hatch for restrictive CSPs.
  3. Direct binary download of the release asset — last resort.
  4. Otherwise: clear error + link to import manually.
- **Import** — `dataverseApi.importSolutionAsync()` then poll `asyncoperations` / `importjobs`; `403` → explicit "needs admin" message.
- **UX** — persistent `UpdateBanner` (available/downloading/importing/done/error); Settings toggle "Check for updates on load"; dismissing "Later" remembers the version.
- **Pipeline** — `release.yml` publishes the managed solution base64 as `update/v<version>.{json,js}` to `gh-pages` (`peaceiris/actions-gh-pages`, `keep_files: true`).

## Ops (done)

- **GitHub Pages enabled** (source: `gh-pages` /) → https://allandecastro.github.io/dataverse-erd-visualizer/ is live. Verified Pages returns `access-control-allow-origin: *` and `content-type: application/javascript`.

## To verify before merge / prod

- **Dataverse CSP**: a restrictive `script-src`/`connect-src` could block loading from github.io (both fetch and script). Check the browser console in the target env; if blocked, the "assisted" (manual import) path is the fallback.
- **SRI** is intentionally deferred until after the first real test. The pipeline already publishes the sha384 hash in `latest.json`; the loader accepts an optional `integrity` param (off by default).

## Verification

`tsc` ✓ · `eslint` ✓ · **629 tests** ✓ · `release.yml` YAML ✓ · `npm run build` ✓ · `npm run build:webresource` ✓.